### PR TITLE
D segments: require right chain type and relax alignment stringency

### DIFF
--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1531,14 +1531,19 @@ pub fn annotate_seq_core(
                     if gene.contains('*') {
                         gene = gene.before("*").to_string();
                     }
-                    use io_utils::*; // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                    printme!(mismatches.len(), matches, gene); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     results.push((mismatches.len(), matches, *t, gene, m as usize, mismatches));
                 }
             }
         }
         results.sort();
         if !results.is_empty() && results[0].0 <= MAX_MISMATCHES {
+
+            // XXX:
+            for i in 0..results.len() {
+                println!("mismatches = {}, matches = {}, m = {}, t = {}, gene = {}",
+                    results[i].0, results[i].1, results[i].4, results[i].2, results[i].3);
+            }
+            
             let mut to_delete = vec![false; results.len()];
             for i in 1..results.len() {
                 if results[i].3 == results[0].3 {

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1469,10 +1469,12 @@ pub fn annotate_seq_core(
     for i1 in 0..annx.len() {
         let t1 = annx[i1].2 as usize;
         if refdata.segtype[t1] == "D".to_string() {
+            println!("found D"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             let mut have_v = false;
             for i2 in 0..annx.len() {
                 let t2 = annx[i2].2 as usize;
                 if refdata.segtype[t2] == "V".to_string() {
+                    println!("found matching V"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     if refdata.rtype[t1] == refdata.rtype[t2] {
                         have_v = true;
                     }

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1528,7 +1528,7 @@ pub fn annotate_seq_core(
                         }
                     }
                     if !mismatch {
-                        println!("adding D"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                        println!("adding D with rtype {}", refdata.rtype[*t]); // XXXXXXXXXXXXXXXXX
                         annx.push((m, r.len() as i32, *t as i32, 0, Vec::new()));
                         annx.sort();
                         break 'outer;

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1531,6 +1531,8 @@ pub fn annotate_seq_core(
                     if gene.contains('*') {
                         gene = gene.before("*").to_string();
                     }
+                    use io_utils::*; // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                    printme!(mismatches, matches); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     results.push((mismatches, matches, *t, gene, m as usize));
                 }
             }

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1468,14 +1468,11 @@ pub fn annotate_seq_core(
     let mut to_delete: Vec<bool> = vec![false; annx.len()];
     for i1 in 0..annx.len() {
         let t1 = annx[i1].2 as usize;
-        println!("{}", refdata.segtype[t1]); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         if refdata.segtype[t1] == "D".to_string() {
-            println!("found D"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             let mut have_v = false;
             for i2 in 0..annx.len() {
                 let t2 = annx[i2].2 as usize;
                 if refdata.segtype[t2] == "V".to_string() {
-                    println!("found matching V"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     if refdata.rtype[t1] == refdata.rtype[t2] {
                         have_v = true;
                     }
@@ -1528,7 +1525,6 @@ pub fn annotate_seq_core(
                         }
                     }
                     if !mismatch {
-                        println!("adding D with rtype {}", refdata.rtype[*t]); // XXXXXXXXXXXXXXXXX
                         annx.push((m, r.len() as i32, *t as i32, 0, Vec::new()));
                         annx.sort();
                         break 'outer;

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1511,7 +1511,7 @@ pub fn annotate_seq_core(
         }
     }
     if v && !d && j {
-        let mut results = Vec::<(usize, usize, usize, String, usize)>::new();
+        let mut results = Vec::<(usize, usize, usize, String, usize, Vec<i32>)>::new();
         let start = max(0, vstop - VJTRIM);
         let stop = min(b.len() as i32, jstart + VJTRIM);
         const MAX_MISMATCHES: usize = 3;
@@ -1520,20 +1520,20 @@ pub fn annotate_seq_core(
             if refdata.rtype[*t] == v_rtype {
                 let r = &refdata.refs[*t];
                 for m in start..=stop - (r.len() as i32) {
-                    let mut mismatches = 0;
+                    let mut mismatches = Vec::<i32>::new();
                     for x in 0..r.len() {
                         if r.get(x) != b.get((m + x as i32) as usize) {
-                            mismatches += 1;
+                            mismatches.push(x as i32);
                         }
                     }
-                    let matches = r.len() - mismatches;
+                    let matches = r.len() - mismatches.len();
                     let mut gene = refdata.name[*t].clone();
                     if gene.contains('*') {
                         gene = gene.before("*").to_string();
                     }
                     use io_utils::*; // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                    printme!(mismatches, matches, gene); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                    results.push((mismatches, matches, *t, gene, m as usize));
+                    printme!(mismatches.len(), matches, gene); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                    results.push((mismatches.len(), matches, *t, gene, m as usize, mismatches));
                 }
             }
         }
@@ -1555,7 +1555,7 @@ pub fn annotate_seq_core(
                     let t = results[0].2;
                     let r = results[0].0 + results[0].1;
                     let m = results[0].4;
-                    annx.push((m as i32, r as i32, t as i32, 0, Vec::new()));
+                    annx.push((m as i32, r as i32, t as i32, 0, results[0].5.clone()));
                     annx.sort();
                 }
             }

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1486,7 +1486,12 @@ pub fn annotate_seq_core(
     erase_if(&mut annx, &to_delete);
 
     // For IGH and TRB, if there is a V and J, but no D, look for a D that matches nearly perfectly
-    // between them.
+    // between them.  We consider only alignments having no indels.  The following conditions
+    // are required:
+    // 1. At most three mismatches.
+    // 2. Excluding genes having the same name:
+    //    (a) all others have more mismatches
+    //    (b) all others have no more matches.
 
     let (mut v, mut d, mut j) = (false, false, false);
     let (mut vstop, mut jstart) = (0, 0);
@@ -1515,7 +1520,6 @@ pub fn annotate_seq_core(
         let start = max(0, vstop - VJTRIM);
         let stop = min(b.len() as i32, jstart + VJTRIM);
         const MAX_MISMATCHES: usize = 3;
-        println!("\nlooking for D segment matches"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         for t in refdata.ds.iter() {
             if refdata.rtype[*t] == v_rtype {
                 let r = &refdata.refs[*t];
@@ -1537,13 +1541,6 @@ pub fn annotate_seq_core(
         }
         results.sort();
         if !results.is_empty() && results[0].0 <= MAX_MISMATCHES {
-
-            // XXX:
-            for i in 0..results.len() {
-                println!("mismatches = {}, matches = {}, m = {}, t = {}, gene = {}",
-                    results[i].0, results[i].1, results[i].4, results[i].2, results[i].3);
-            }
-            
             let mut to_delete = vec![false; results.len()];
             for i in 1..results.len() {
                 if results[i].3 == results[0].3 {

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1468,6 +1468,7 @@ pub fn annotate_seq_core(
     let mut to_delete: Vec<bool> = vec![false; annx.len()];
     for i1 in 0..annx.len() {
         let t1 = annx[i1].2 as usize;
+        println!("{}", refdata.segtype[t1]); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         if refdata.segtype[t1] == "D".to_string() {
             println!("found D"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             let mut have_v = false;
@@ -1524,6 +1525,7 @@ pub fn annotate_seq_core(
                     }
                 }
                 if !mismatch {
+                    println!("adding D"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     annx.push((m, r.len() as i32, *t as i32, 0, Vec::new()));
                     annx.sort();
                     break 'outer;

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1515,6 +1515,7 @@ pub fn annotate_seq_core(
         let start = max(0, vstop - VJTRIM);
         let stop = min(b.len() as i32, jstart + VJTRIM);
         const MAX_MISMATCHES: usize = 3;
+        println!("\nlooking for D segment matches"); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
         for t in refdata.ds.iter() {
             if refdata.rtype[*t] == v_rtype {
                 let r = &refdata.refs[*t];
@@ -1532,7 +1533,7 @@ pub fn annotate_seq_core(
                         gene = gene.before("*").to_string();
                     }
                     use io_utils::*; // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                    printme!(mismatches, matches); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+                    printme!(mismatches, matches, gene); // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                     results.push((mismatches, matches, *t, gene, m as usize));
                 }
             }

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1524,7 +1524,6 @@ pub fn annotate_seq_core(
                     for x in 0..r.len() {
                         if r.get(x) != b.get((m + x as i32) as usize) {
                             mismatches += 1;
-                            break;
                         }
                     }
                     let matches = r.len() - mismatches;

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -1462,6 +1462,29 @@ pub fn annotate_seq_core(
         }
     }
 
+    // If there is a D gene alignment that is from a different chain type than the V gene
+    // alignment, delete it.
+
+    let mut to_delete: Vec<bool> = vec![false; annx.len()];
+    for i1 in 0..annx.len() {
+        let t1 = annx[i1].2 as usize;
+        if refdata.segtype[t1] == "D".to_string() {
+            let mut have_v = false;
+            for i2 in 0..annx.len() {
+                let t2 = annx[i2].2 as usize;
+                if refdata.segtype[t2] == "V".to_string() {
+                    if refdata.rtype[t1] == refdata.rtype[t2] {
+                        have_v = true;
+                    }
+                }
+            }
+            if !have_v {
+                to_delete[i1] = true;
+            }
+        }
+    }
+    erase_if(&mut annx, &to_delete);
+
     // For IGH and TRB, if there is a V and J, but no D, look for a D that matches perfectly
     // between them.
 


### PR DESCRIPTION
Previously a D was aligned if it had a 12-base perfect match or aligned perfectly end-to-end.
Now we do this:
    // For IGH and TRB, if there is a V and J, but no D, look for a D that matches nearly perfectly
    // between them.  We consider only alignments having no indels.  The following conditions 
    // are required:
    // 1. At most three mismatches.
    // 2. Excluding genes having the same name:
    //    (a) all others have more mismatches
    //    (b) all others have no more matches.
Also, we require that the D segment has the right chain type.
Testing: looked at one BCR and one TCR human dataset.  More D segments are aligned now.
Didn't see anything surprising.