### PR TITLE
Relax version constraint on intertools to 0.9.

### DIFF
--- a/align_tools/Cargo.toml
+++ b/align_tools/Cargo.toml
@@ -8,5 +8,5 @@ description = "Some tools that are 'internal' for now because they are insuffici
 [dependencies]
 bio = "0.31"
 debruijn = { git = "https://github.com/10XGenomics/rust-debruijn.git" }
-itertools = "0.8"
+itertools = ">= 0.8, <= 0.9"
 vector_utils = "0.1.0"

--- a/tables/Cargo.toml
+++ b/tables/Cargo.toml
@@ -7,5 +7,5 @@ description = "Some tools that are 'internal' for now because they are insuffici
 
 [dependencies]
 io_utils = "0.2.3"
-itertools = "0.8"
+itertools = ">= 0.8, <= 0.9"
 string_utils = "0.1.0"

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -14,7 +14,7 @@ fasta = { path = "../fasta" }
 flate2 = "1.0.12"
 hyper = { path = "../hyper" }
 io_utils = "0.2.4"
-itertools = "0.8"
+itertools = ">= 0.8, <= 0.9"
 kmer_lookup = { path = "../kmer_lookup" }
 pretty_trace = "0.3"
 serde = "1.0.90"


### PR DESCRIPTION
This matches related crates such as bio.