### PR TITLE
Add include directives to Cargo.tomls

### DIFF
--- a/ansi_escape/Cargo.toml
+++ b/ansi_escape/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 string_utils = "0.1"

--- a/dna/Cargo.toml
+++ b/dna/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]

--- a/fasta_tools/Cargo.toml
+++ b/fasta_tools/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 debruijn = "0.3.2"

--- a/io_utils/Cargo.toml
+++ b/io_utils/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 repository = "https://github.com/10XGenomics/rust-toolbox"
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 [dependencies]
 bincode = "1.1.3"

--- a/load_feature_bc/Cargo.toml
+++ b/load_feature_bc/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 flate2 = "1.0.20"

--- a/mirror_sparse_matrix/Cargo.toml
+++ b/mirror_sparse_matrix/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 binary_vec_io = "0.1"

--- a/perf_stats/Cargo.toml
+++ b/perf_stats/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 io_utils = "0.2"

--- a/pretty_trace/Cargo.toml
+++ b/pretty_trace/Cargo.toml
@@ -8,6 +8,7 @@ description = "Tools for generating pretty tracebacks and for profiling."
 homepage = "https://github.com/10XGenomics/rust-toolbox/tree/master/pretty_trace"
 keywords = ["stack", "trace", "traceback", "profiling"]
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 [dependencies]
 backtrace = "0.3.40"

--- a/pretty_trace/Cargo.toml
+++ b/pretty_trace/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/10XGenomics/rust-toolbox/tree/master/pretty_trace
 keywords = ["stack", "trace", "traceback", "profiling"]
 edition = "2018"
 include = ["src/lib.rs", "LICENSE", "README.md"]
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 backtrace = "0.3.40"

--- a/stats_utils/Cargo.toml
+++ b/stats_utils/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 [dependencies]

--- a/stats_utils/Cargo.toml
+++ b/stats_utils/Cargo.toml
@@ -6,5 +6,6 @@ license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
 include = ["src/lib.rs", "LICENSE", "README.md"]
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]

--- a/stirling_numbers/Cargo.toml
+++ b/stirling_numbers/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "A few functions relating to Stirling numbers of the second kind."
 homepage = "https://github.com/10XGenomics/rust-toolbox/tree/master/stirling_numbers"
 edition = "2018"
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 num-traits = "^0.2"

--- a/string_utils/Cargo.toml
+++ b/string_utils/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 [dependencies]
 vector_utils = "0.1.3"

--- a/string_utils/Cargo.toml
+++ b/string_utils/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 edition = "2018"
 include = ["src/lib.rs", "LICENSE", "README.md"]
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 vector_utils = "0.1.3"

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -8,6 +8,7 @@ description = "Some tools that are 'internal' for now because they are insuffici
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 # This crate is not published because it is too big.
+include = ["src/**/*"]
 
 [dependencies]
 align_tools = "0.1"

--- a/vdj_types/Cargo.toml
+++ b/vdj_types/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
+repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 enum-iterator = "0.6.0"

--- a/vector_utils/Cargo.toml
+++ b/vector_utils/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."
 repository = "https://github.com/10XGenomics/rust-toolbox"
 edition = "2018"
+include = ["src/lib.rs", "LICENSE", "README.md"]
 
 [dependencies]
 permutation = "0.2.5"


### PR DESCRIPTION
These directives control which files are downloaded when someone gets
the crate from crates.io.  It is good practice to exclude test files,
READMEs, and so on in order to minimize the download.

The main impact of this is on the 50+mb of fasta files in vdj_ann, but
there's also a relatively large jpg image for pretty_trace.

See https://github.com/the-lean-crate/criner for further information.