### PR TITLE
Loosen version constraint on bio.

### DIFF
--- a/align_tools/Cargo.toml
+++ b/align_tools/Cargo.toml
@@ -7,7 +7,7 @@ description = "Some tools that are 'internal' for now because they are insuffici
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-bio = "0.31"
+bio = ">=0.31"
 debruijn = "0.3.2"
 itertools = ">= 0.8, <= 0.9"
 vector_utils = "0.1.3"

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 [dependencies]
 align_tools = "0.1.1"
 amino = "0.1.1"
-bio = "0.31"
+bio = ">=0.31"
 debruijn = "0.3.2"
 exons = "0.1.2"
 fasta_tools = "0.1.1"


### PR DESCRIPTION
Need up update bio in cellranger, and that means updating it in all of
cellranger's dependencies first.  Just loosening the version constraint
here so that we don't have to go through this whole song and dance every
time.