### PR TITLE
Update bio dependency to 0.33.

### DIFF
--- a/align_tools/Cargo.toml
+++ b/align_tools/Cargo.toml
@@ -8,8 +8,7 @@ description = "Some tools that are 'internal' for now because they are insuffici
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-bio = { git = "https://github.com/rust-bio/rust-bio.git", rev = "792d3e21296d85a711f1a383db513924528b6da5" }
-# bio = ">=0.32"
+bio = ">=0.33"
 debruijn = "0.3.2"
 itertools = ">= 0.8, <= 0.11"
 vector_utils = "0.1.3"

--- a/master.toml
+++ b/master.toml
@@ -1,8 +1,8 @@
-align_tools = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev="591b502c92a7d3825fbe7bb20994e0787cc29a9d" }
+align_tools = { path = "../align_tools" }
 amino = "0.1"
 ansi_escape = "0.1"
 binary_vec_io = "0.1.8"
-bio = { git = "https://github.com/rust-bio/rust-bio.git", rev = "792d3e21296d85a711f1a383db513924528b6da5" }
+bio = ">=0.33"
 debruijn = "0.3.2"
 dna = "0.1.1"
 enum-iterator = "0.6.0"

--- a/master.toml
+++ b/master.toml
@@ -1,4 +1,4 @@
-align_tools = { path = "../align_tools" }
+align_tools = "0.1.2"
 amino = "0.1"
 ansi_escape = "0.1"
 binary_vec_io = "0.1.8"

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 # This crate is not published because it is too big.
 
 [dependencies]
-align_tools = { git = "https://github.com/10XGenomics/rust-toolbox.git", rev="591b502c92a7d3825fbe7bb20994e0787cc29a9d" }
+align_tools = { path = "../align_tools" }
 amino = "0.1"
-bio = { git = "https://github.com/rust-bio/rust-bio.git", rev = "792d3e21296d85a711f1a383db513924528b6da5" }
+bio = ">=0.33"
 debruijn = "0.3.2"
 exons = "0.1"
 fasta_tools = "0.1"

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 # This crate is not published because it is too big.
 
 [dependencies]
-align_tools = { path = "../align_tools" }
+align_tools = "0.1.2"
 amino = "0.1"
 bio = ">=0.33"
 debruijn = "0.3.2"


### PR DESCRIPTION
Rather than a git revision.

Also, have vdj_ann depend on align_tools by path rather than git commit.
crates.io does not allow published crates to depend by git commit
anyway, and depending by git commit sha that way makes it impossible for
other crates to import vdn_ann by git sha without having two different
versions of this repo checked out (since vdj_ann can't refer to a commit
which doesn't exist yet).