### PR TITLE
Many API cleanups.

### DIFF
--- a/align_tools/Cargo.toml
+++ b/align_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "align_tools"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/align_tools/src/lib.rs
+++ b/align_tools/src/lib.rs
@@ -198,7 +198,7 @@ pub fn affine_align(x: &DnaString, y: &DnaString) -> Alignment {
 // are used and would need to be tweaked if other operations are present.  You can set width to
 // the expected terminal width.
 
-pub fn vis_align(s1: &[u8], s2: &[u8], ops: &Vec<AlignmentOperation>, width: usize) -> String {
+pub fn vis_align(s1: &[u8], s2: &[u8], ops: &[AlignmentOperation], width: usize) -> String {
     let (mut pos1, mut pos2) = (0, 0);
     let (mut t1, mut t2) = (Vec::<u8>::new(), Vec::<u8>::new());
     let mut d = Vec::<u8>::new();

--- a/ansi_escape/Cargo.toml
+++ b/ansi_escape/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ansi_escape"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/ansi_escape/src/ansi_to_html.rs
+++ b/ansi_escape/src/ansi_to_html.rs
@@ -55,10 +55,11 @@ pub fn convert_text_with_ansi_escapes_to_svg(
 
     let lines0 = x.split('\n').collect::<Vec<&str>>();
     let height = vsep * (lines0.len() as f64 - 1.2);
-    let mut lines = Vec::<String>::new();
-    lines.push("<svg version=\"1.1\"".to_string());
-    lines.push("".to_string()); // PLACEHOLDER
-    lines.push("xmlns=\"http://www.w3.org/2000/svg\">".to_string());
+    let mut lines = vec![
+        "<svg version=\"1.1\"".to_string(),
+        String::default(), // PLACEHOLDER
+        "xmlns=\"http://www.w3.org/2000/svg\">".to_string(),
+    ];
     let mut max_width = 0;
     for m in 0..lines0.len() {
         let t = &lines0[m];
@@ -211,8 +212,8 @@ pub fn compress_ansi_escapes(x: &str) -> String {
                             end = Some(i);
                         }
                     }
-                    if end.is_some() {
-                        escapes = escapes[end.unwrap() + 1..escapes.len()].to_vec();
+                    if let Some(end) = end {
+                        escapes = escapes[end + 1..escapes.len()].to_vec();
                     }
                     if escapes.is_empty() {
                         // Emit end escape.
@@ -431,7 +432,7 @@ impl ColorState {
 
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-fn merge(s: &Vec<ColorState>) -> ColorState {
+fn merge(s: &[ColorState]) -> ColorState {
     let mut x = ColorState::default();
     for i in 0..s.len() {
         if s[i].null() {

--- a/binary_vec_io/Cargo.toml
+++ b/binary_vec_io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binary_vec_io"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/binary_vec_io/src/lib.rs
+++ b/binary_vec_io/src/lib.rs
@@ -76,7 +76,7 @@ pub fn binary_read_to_ref<T>(f: &mut std::fs::File, p: &mut T, n: usize) -> Resu
 // in the first case, or to a vector, in the second case.
 
 #[allow(dead_code)]
-pub fn binary_write_vec<T>(f: &mut std::fs::File, x: &Vec<T>) -> Result<(), Error>
+pub fn binary_write_vec<T>(f: &mut std::fs::File, x: &[T]) -> Result<(), Error>
 where
     T: BinaryInputOutputSafe,
 {
@@ -112,7 +112,7 @@ where
     binary_read_to_ref::<T>(f, &mut x[len], n)
 }
 
-pub fn binary_write_vec_vec<T>(f: &mut std::fs::File, x: &Vec<Vec<T>>) -> Result<(), Error>
+pub fn binary_write_vec_vec<T>(f: &mut std::fs::File, x: &[Vec<T>]) -> Result<(), Error>
 where
     T: BinaryInputOutputSafe,
 {

--- a/dna/Cargo.toml
+++ b/dna/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dna"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/dna/src/lib.rs
+++ b/dna/src/lib.rs
@@ -44,7 +44,7 @@ pub fn tm_nearest_neighbor(s: &str) -> f64 {
     tm_nearest_neighbor_full(s, 0.00000025, 0.05, &locked)
 }
 
-pub fn tm_nearest_neighbor_full(s: &str, s_mol: f64, na_mol: f64, locked: &Vec<bool>) -> f64 {
+pub fn tm_nearest_neighbor_full(s: &str, s_mol: f64, na_mol: f64, locked: &[bool]) -> f64 {
     // Allow for + symbols.
 
     if s.contains('+') {
@@ -52,11 +52,8 @@ pub fn tm_nearest_neighbor_full(s: &str, s_mol: f64, na_mol: f64, locked: &Vec<b
         assert!(!s.contains("++"));
         assert!(!s.ends_with('+'));
         let mut sx = String::new();
-        let mut lockedx = Vec::<bool>::new();
-        let mut schars = Vec::<char>::new();
-        for c in s.chars() {
-            schars.push(c);
-        }
+        let schars: Vec<char> = s.chars().collect();
+        let mut lockedx = Vec::<bool>::with_capacity(schars.len());
         let mut i = 0;
         while i < schars.len() {
             if schars[i] != '+' {
@@ -365,7 +362,7 @@ pub fn thermodynamic_sums_dna(
     dg_sum: &mut f64,
     include_symmetry_correction: bool,
     include_initiation_terms: bool,
-    locked: &Vec<bool>,
+    locked: &[bool],
 ) {
     // defaults for last: true, true, empty
 

--- a/exons/Cargo.toml
+++ b/exons/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "exons"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/exons/src/lib.rs
+++ b/exons/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 use string_utils::TextUtils;
 use vector_utils::unique_sort;
 
-pub fn fetch_exons(species: &String, exons: &mut Vec<(String, i32, i32, bool, String, i32)>) {
+pub fn fetch_exons(species: &str, exons: &mut Vec<(String, i32, i32, bool, String, i32)>) {
     assert!(species == "human" || species == "mouse");
 
     // Define gtf file location.  See notes in bin/build_vdj_ref.fs.

--- a/expr_tools/Cargo.toml
+++ b/expr_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expr_tools"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/expr_tools/src/lib.rs
+++ b/expr_tools/src/lib.rs
@@ -8,7 +8,7 @@
 use evalexpr::{ContextWithMutableFunctions, ContextWithMutableVariables, HashMapContext};
 use evalexpr::{Function, Value};
 use statrs::distribution::ContinuousCDF;
-use string_utils::*;
+use string_utils::TextUtils;
 use vector_utils::{bin_member, unique_sort};
 
 // ================================================================================================
@@ -124,7 +124,7 @@ macro_rules! evalexpr_fn3 {
 // to be called on arbitrary strings, but if the strings are not all f64, then the return value is
 // null.
 
-pub fn define_evalexpr_context(vars: &Vec<String>, vals: &Vec<String>) -> evalexpr::HashMapContext {
+pub fn define_evalexpr_context(vars: &[String], vals: &[String]) -> evalexpr::HashMapContext {
     assert_eq!(vars.len(), vals.len());
     let mut c = HashMapContext::new();
 

--- a/fasta_tools/Cargo.toml
+++ b/fasta_tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fasta_tools"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/fasta_tools/src/lib.rs
+++ b/fasta_tools/src/lib.rs
@@ -9,58 +9,64 @@ use std::process::Command;
 use std::{
     fs::File,
     io::{prelude::*, BufReader},
+    path::Path,
 };
 use string_utils::TextUtils;
 
 // Read a fasta file or gzipped fasta file and convert to a Vec<Vec<u8>>, in which
 // outer vec entries alternate between header lines and base lines.
 
-pub fn read_fasta_to_vec_vec_u8(f: &str) -> Vec<Vec<u8>> {
+pub fn read_fasta_to_vec_vec_u8(f: impl AsRef<Path>) -> Vec<Vec<u8>> {
     let mut x = Vec::<Vec<u8>>::new();
-    if !f.ends_with(".gz") {
-        let fin = open_for_read![&f];
-        let mut last: String = String::new();
-        let mut first = true;
-        for line in fin.lines() {
-            let s = line.unwrap();
-            if first {
-                if !s.starts_with('>') {
-                    panic!("fasta format failure reading {}", f);
+    let f = f.as_ref();
+    match f.extension() {
+        Some(ex) if ex == "gz" => {
+            // TODO: pass `&Path` directly rather than `&str` once io_utils is updated.
+            let fin = open_for_read![f.to_str().unwrap()];
+            let mut last: String = String::new();
+            let mut first = true;
+            for line in fin.lines() {
+                let s = line.unwrap();
+                if first {
+                    if !s.starts_with('>') {
+                        panic!("fasta format failure reading {}", f.to_string_lossy());
+                    }
+                    first = false;
+                    x.push(s.get(1..).unwrap().as_bytes().to_vec());
+                } else if s.starts_with('>') {
+                    x.push(last.as_bytes().to_vec());
+                    last.clear();
+                    x.push(s.get(1..).unwrap().as_bytes().to_vec());
+                } else {
+                    last += &s;
                 }
-                first = false;
-                x.push(s.get(1..).unwrap().as_bytes().to_vec());
-            } else if s.starts_with('>') {
-                x.push(last.as_bytes().to_vec());
-                last.clear();
-                x.push(s.get(1..).unwrap().as_bytes().to_vec());
-            } else {
-                last += &s;
             }
+            x.push(last.as_bytes().to_vec());
         }
-        x.push(last.as_bytes().to_vec());
-    } else {
-        let gz = MultiGzDecoder::new(std::fs::File::open(&f).unwrap());
-        let fin = std::io::BufReader::new(gz);
-        let mut last: String = String::new();
-        let mut first = true;
-        for line in fin.lines() {
-            let s = line.unwrap();
-            if first {
-                if !s.starts_with('>') {
-                    panic!("fasta format failure");
+        _ => {
+            let gz = MultiGzDecoder::new(std::fs::File::open(&f).unwrap());
+            let fin = std::io::BufReader::new(gz);
+            let mut last: String = String::new();
+            let mut first = true;
+            for line in fin.lines() {
+                let s = line.unwrap();
+                if first {
+                    if !s.starts_with('>') {
+                        panic!("fasta format failure");
+                    }
+                    first = false;
+                    x.push(s.get(1..).unwrap().as_bytes().to_vec());
+                } else if s.starts_with('>') {
+                    x.push(last.as_bytes().to_vec());
+                    last.clear();
+                    x.push(s.get(1..).unwrap().as_bytes().to_vec());
+                } else {
+                    last += &s;
                 }
-                first = false;
-                x.push(s.get(1..).unwrap().as_bytes().to_vec());
-            } else if s.starts_with('>') {
-                x.push(last.as_bytes().to_vec());
-                last.clear();
-                x.push(s.get(1..).unwrap().as_bytes().to_vec());
-            } else {
-                last += &s;
             }
+            x.push(last.as_bytes().to_vec());
         }
-        x.push(last.as_bytes().to_vec());
-    }
+    };
     x
 }
 
@@ -69,58 +75,63 @@ pub fn read_fasta_to_vec_vec_u8(f: &str) -> Vec<Vec<u8>> {
 // ◼ Kill the code duplication below.
 
 pub fn read_fasta_into_vec_dna_string_plus_headers(
-    f: &String,
+    f: impl AsRef<Path>,
     dv: &mut Vec<DnaString>,
     headers: &mut Vec<String>,
 ) {
-    if !f.ends_with(".gz") {
-        let fin = open_for_read![&f];
-        let mut last: String = String::new();
-        let mut first = true;
-        for line in fin.lines() {
-            let s = line.unwrap();
-            if first {
-                if !s.starts_with('>') {
-                    panic!("fasta format failure reading {}", f);
+    let f = f.as_ref();
+    match f.extension() {
+        Some(ex) if ex == "gz" => {
+            // TODO: pass `&Path` directly rather than `&str` once io_utils is updated.
+            let fin = open_for_read![f.to_str().unwrap()];
+            let mut last: String = String::new();
+            let mut first = true;
+            for line in fin.lines() {
+                let s = line.unwrap();
+                if first {
+                    if !s.starts_with('>') {
+                        panic!("fasta format failure reading {}", f.to_string_lossy());
+                    }
+                    first = false;
+                    headers.push(s.get(1..).unwrap().to_string());
+                } else if s.starts_with('>') {
+                    dv.push(DnaString::from_dna_string(&last));
+                    last.clear();
+                    headers.push(s.get(1..).unwrap().to_string());
+                } else {
+                    last += &s;
                 }
-                first = false;
-                headers.push(s.get(1..).unwrap().to_string());
-            } else if s.starts_with('>') {
-                dv.push(DnaString::from_dna_string(&last));
-                last.clear();
-                headers.push(s.get(1..).unwrap().to_string());
-            } else {
-                last += &s;
             }
+            dv.push(DnaString::from_dna_string(&last));
         }
-        dv.push(DnaString::from_dna_string(&last));
-    } else {
-        let gz = MultiGzDecoder::new(std::fs::File::open(&f).unwrap());
-        let fin = std::io::BufReader::new(gz);
-        let mut last: String = String::new();
-        let mut first = true;
-        for line in fin.lines() {
-            let s = line.unwrap();
-            if first {
-                if !s.starts_with('>') {
-                    panic!("fasta format failure");
+        _ => {
+            let gz = MultiGzDecoder::new(std::fs::File::open(&f).unwrap());
+            let fin = std::io::BufReader::new(gz);
+            let mut last: String = String::new();
+            let mut first = true;
+            for line in fin.lines() {
+                let s = line.unwrap();
+                if first {
+                    if !s.starts_with('>') {
+                        panic!("fasta format failure");
+                    }
+                    first = false;
+                    headers.push(s.get(1..).unwrap().to_string());
+                } else if s.starts_with('>') {
+                    dv.push(DnaString::from_dna_string(&last));
+                    last.clear();
+                    headers.push(s.get(1..).unwrap().to_string());
+                } else {
+                    last += &s;
                 }
-                first = false;
-                headers.push(s.get(1..).unwrap().to_string());
-            } else if s.starts_with('>') {
-                dv.push(DnaString::from_dna_string(&last));
-                last.clear();
-                headers.push(s.get(1..).unwrap().to_string());
-            } else {
-                last += &s;
             }
+            dv.push(DnaString::from_dna_string(&last));
         }
-        dv.push(DnaString::from_dna_string(&last));
-    }
+    };
 }
 
 pub fn read_fasta_contents_into_vec_dna_string_plus_headers(
-    f: &String,
+    f: &str,
     dv: &mut Vec<DnaString>,
     headers: &mut Vec<String>,
 ) {
@@ -148,15 +159,17 @@ pub fn read_fasta_contents_into_vec_dna_string_plus_headers(
 
 // This APPENDS.
 
-pub fn read_fasta_headers(f: &String, headers: &mut Vec<String>) {
-    let fin = open_for_read![&f];
+pub fn read_fasta_headers(f: impl AsRef<Path>, headers: &mut Vec<String>) {
+    let f = f.as_ref();
+    // TODO: Don't convert to str.
+    let fin = open_for_read![f.to_str().unwrap()];
     let mut last: String = String::new();
     let mut first = true;
     for line in fin.lines() {
         let s = line.unwrap();
         if first {
             if !s.starts_with('>') {
-                panic!("fasta format failure reading {}", f);
+                panic!("fasta format failure reading {}", f.to_string_lossy());
             }
             first = false;
             headers.push(s.get(1..).unwrap().to_string());
@@ -173,7 +186,7 @@ pub fn read_fasta_headers(f: &String, headers: &mut Vec<String>) {
 // LOAD GENBANK ACCESSION
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-pub fn load_genbank_accession(accession: &String, bases: &mut DnaString) {
+pub fn load_genbank_accession(accession: &str, bases: &mut DnaString) {
     let link = format!(
         "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/\
          efetch.fcgi?db=nucleotide&amp;id={}&amp;rettype=fasta",
@@ -184,7 +197,7 @@ pub fn load_genbank_accession(accession: &String, bases: &mut DnaString) {
         .arg(format!("curl \"{}\"", link))
         .output()
         .expect("failed to execute curl command");
-    let fasta = String::from_utf8(o.stdout).unwrap();
+    let fasta = String::from_utf8(o.stdout).expect("Response was not valid utf-8.");
     let mut fasta = fasta.after("\n").to_string();
     // ◼ The following assert should not be necessary: the DnaString constructor
     // ◼ should gag if it gets nonsense input.

--- a/graph_simple/Cargo.toml
+++ b/graph_simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph_simple"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/graph_simple/src/lib.rs
+++ b/graph_simple/src/lib.rs
@@ -64,9 +64,9 @@ pub trait GraphSimple<T> {
     // get_predecessors1 and get_successors1: start from one vertex
     // =============================================================================
 
-    fn get_predecessors(&self, v: &Vec<i32>, x: &mut Vec<u32>);
+    fn get_predecessors(&self, v: &[i32], x: &mut Vec<u32>);
     fn get_predecessors1(&self, v: i32, x: &mut Vec<u32>);
-    fn get_successors(&self, v: &Vec<i32>, x: &mut Vec<u32>);
+    fn get_successors(&self, v: &[i32], x: &mut Vec<u32>);
     fn get_successors1(&self, v: i32, x: &mut Vec<u32>);
 
     // =============================================================================
@@ -171,7 +171,7 @@ where
         self.edge_obj(self.e_to(v, n) as u32)
     }
 
-    fn get_predecessors(&self, v: &Vec<i32>, x: &mut Vec<u32>) {
+    fn get_predecessors(&self, v: &[i32], x: &mut Vec<u32>) {
         let mut check: Vec<u32> = Vec::new();
         let mut tov: HashSet<u32> = HashSet::new();
         for j in 0..v.len() {
@@ -203,7 +203,7 @@ where
         self.get_predecessors(&vs, x);
     }
 
-    fn get_successors(&self, v: &Vec<i32>, x: &mut Vec<u32>) {
+    fn get_successors(&self, v: &[i32], x: &mut Vec<u32>) {
         let mut check: Vec<u32> = Vec::new();
         let mut fromv: HashSet<u32> = HashSet::new();
         for j in 0..v.len() {

--- a/hyperbase/src/lib.rs
+++ b/hyperbase/src/lib.rs
@@ -60,12 +60,10 @@ pub fn debruijn_to_petgraph_hyperbasevector<K: Kmer>(
         // Update involution.
 
         let palindrome = seq == seq.rc();
-        if palindrome {
-            inv.push(edges.len() as u32);
-        } else {
+        if !palindrome {
             inv.push((edges.len() + 1) as u32);
-            inv.push(edges.len() as u32);
         }
+        inv.push(edges.len() as u32);
 
         // Save edge.
 
@@ -218,6 +216,12 @@ impl HyperBasevector {
     }
 }
 
+impl Default for HyperBasevector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 // HYPER DEFINITION
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
@@ -247,7 +251,7 @@ impl Hyper {
     // Return the sequence associated to a path.
     // =============================================================================
 
-    pub fn cat(&self, p: &Vec<i32>) -> DnaString {
+    pub fn cat(&self, p: &[i32]) -> DnaString {
         let mut s = DnaString::new();
         if p.is_empty() {
             return s;
@@ -296,7 +300,7 @@ impl Hyper {
     // hide_seq: if true, and there is an annotation on an edge, don't print the sequence
     // ============================================================================================
 
-    pub fn print_with_annotations(&self, ann: &Vec<String>, require_ann: bool, hide_seq: bool) {
+    pub fn print_with_annotations(&self, ann: &[String], require_ann: bool, hide_seq: bool) {
         let mut comp = Vec::<Vec<u32>>::new();
         self.h.g.components_e(&mut comp);
         let mut n = 0;
@@ -359,7 +363,7 @@ impl Hyper {
     // Create a new Hyper from data.
     // =============================================================================
 
-    pub fn build_from_reads(&mut self, k: i32, reads: &Vec<DnaString>) {
+    pub fn build_from_reads(&mut self, k: i32, reads: &[DnaString]) {
         // Only works if k = 20.
 
         assert_eq!(k, 20);
@@ -503,10 +507,10 @@ impl Hyper {
     // Normally you would want to call kill_edges instead.
     // =============================================================================
 
-    pub fn kill_edges_raw(&mut self, dels: &Vec<u32>) {
+    pub fn kill_edges_raw(&mut self, dels: &[u32]) {
         // Symmetrize and unique sort dels.
 
-        let mut dels2 = dels.clone();
+        let mut dels2 = dels.to_vec();
         for e in dels {
             dels2.push(self.inv[*e as usize]);
         }
@@ -547,7 +551,7 @@ impl Hyper {
     // documentation in those files that describes some of the logic.
     // =============================================================================
 
-    pub fn kill_edges(&mut self, dels: &Vec<u32>) {
+    pub fn kill_edges(&mut self, dels: &[u32]) {
         // Kill the edges.
 
         self.kill_edges_raw(dels);
@@ -940,5 +944,11 @@ impl Hyper {
             }
         }
         z
+    }
+}
+
+impl Default for Hyper {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/io_utils/Cargo.toml
+++ b/io_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "io_utils"
-version = "0.2.12"
+version = "0.3.0"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/kmer_lookup/Cargo.toml
+++ b/kmer_lookup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kmer_lookup"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/kmer_lookup/src/lib.rs
+++ b/kmer_lookup/src/lib.rs
@@ -15,7 +15,7 @@ use vector_utils::{
 
 /// Given a vector of DnaStrings dv, create a sorted vector whose entries are
 /// (kmer, e, estart), where the kmer starts at position estart on dv[e].
-pub fn make_kmer_lookup_single<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<(K, i32, i32)>) {
+pub fn make_kmer_lookup_single<K: Kmer>(dv: &[DnaString], x: &mut Vec<(K, i32, i32)>) {
     let sz = dv
         .iter()
         .filter(|b| b.len() >= K::k())
@@ -34,17 +34,17 @@ pub fn make_kmer_lookup_single<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<(K, i32
 }
 
 /// Included for backward compatibility. Use make_kmer_lookup_single
-pub fn make_kmer_lookup_20_single(dv: &Vec<DnaString>, x: &mut Vec<(Kmer20, i32, i32)>) {
+pub fn make_kmer_lookup_20_single(dv: &[DnaString], x: &mut Vec<(Kmer20, i32, i32)>) {
     make_kmer_lookup_single(dv, x);
 }
 
 /// Included for backward compatibility. Use make_kmer_lookup_single
-pub fn make_kmer_lookup_12_single(dv: &Vec<DnaString>, x: &mut Vec<(Kmer12, i32, i32)>) {
+pub fn make_kmer_lookup_12_single(dv: &[DnaString], x: &mut Vec<(Kmer12, i32, i32)>) {
     make_kmer_lookup_single(dv, x);
 }
 
 /// Just create a unique sorted vector of kmers.
-pub fn make_kmer_lookup_single_simple<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<K>) {
+pub fn make_kmer_lookup_single_simple<K: Kmer>(dv: &[DnaString], x: &mut Vec<K>) {
     let sz = dv
         .iter()
         .filter(|b| b.len() >= K::k())
@@ -58,16 +58,16 @@ pub fn make_kmer_lookup_single_simple<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<
 }
 
 /// Included for backward compatibility. Use make_kmer_lookup_single_simple
-pub fn make_kmer_lookup_20_single_simple<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<Kmer20>) {
+pub fn make_kmer_lookup_20_single_simple<K: Kmer>(dv: &[DnaString], x: &mut Vec<Kmer20>) {
     make_kmer_lookup_single_simple(dv, x);
 }
 
 /// Included for backward compatibility. Use make_kmer_lookup_single_simple
-pub fn make_kmer_lookup_12_single_simple<K: Kmer>(dv: &Vec<DnaString>, x: &mut Vec<Kmer12>) {
+pub fn make_kmer_lookup_12_single_simple<K: Kmer>(dv: &[DnaString], x: &mut Vec<Kmer12>) {
     make_kmer_lookup_single_simple(dv, x);
 }
 
-pub fn make_kmer_lookup_20_parallel(dv: &Vec<DnaString>, x: &mut Vec<(Kmer20, i32, i32)>) {
+pub fn make_kmer_lookup_20_parallel(dv: &[DnaString], x: &mut Vec<(Kmer20, i32, i32)>) {
     const K: usize = 20; // sadly this does not templatize over K
     x.clear();
     let mut starts: Vec<usize> = Vec::with_capacity(dv.len() + 1);
@@ -110,10 +110,7 @@ pub fn make_kmer_lookup_20_parallel(dv: &Vec<DnaString>, x: &mut Vec<(Kmer20, i3
 // Same but replace each kmer by the min of it and its rc, and if we use rc,
 // adjust pos accordingly.
 
-pub fn make_kmer_lookup_20_oriented_single<K: Kmer>(
-    dv: &Vec<DnaString>,
-    x: &mut Vec<(K, i32, i32)>,
-) {
+pub fn make_kmer_lookup_20_oriented_single<K: Kmer>(dv: &[DnaString], x: &mut Vec<(K, i32, i32)>) {
     let sz = dv
         .iter()
         .filter(|b| b.len() >= K::k())
@@ -141,7 +138,7 @@ pub fn make_kmer_lookup_20_oriented_single<K: Kmer>(
 // Same but replace each kmer by the min of it and its rc, and if we use rc,
 // adjust pos accordingly.
 
-pub fn make_kmer_lookup_oriented_single(dv: &Vec<DnaString>, x: &mut Vec<(Kmer20, i32, i32)>) {
+pub fn make_kmer_lookup_oriented_single(dv: &[DnaString], x: &mut Vec<(Kmer20, i32, i32)>) {
     const K: usize = 20; // this does not templatize over K
                          // Kmer20 probably takes 8 bytes and could take 5.
     x.clear();
@@ -188,7 +185,7 @@ pub fn make_kmer_lookup_oriented_single(dv: &Vec<DnaString>, x: &mut Vec<(Kmer20
 
 // Determine if a sequence perfectly matches in forward orientation.
 
-pub fn match_12(b: &DnaString, dv: &Vec<DnaString>, x: &Vec<(Kmer12, i32, i32)>) -> bool {
+pub fn match_12(b: &DnaString, dv: &[DnaString], x: &[(Kmer12, i32, i32)]) -> bool {
     let y: Kmer12 = b.get_kmer(0);
     let low = lower_bound1_3(x, &y);
     let high = upper_bound1_3(x, &y);

--- a/load_feature_bc/Cargo.toml
+++ b/load_feature_bc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "load_feature_bc"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/mirror_sparse_matrix/Cargo.toml
+++ b/mirror_sparse_matrix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mirror_sparse_matrix"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/mirror_sparse_matrix/src/lib.rs
+++ b/mirror_sparse_matrix/src/lib.rs
@@ -95,23 +95,19 @@ pub fn write_to_file(s: &MirrorSparseMatrix, f: &str) {
     binary_write_vec::<u8>(&mut ff, &s.x).unwrap();
 }
 
-fn get_u8_at_pos(v: &Vec<u8>, pos: usize) -> u8 {
+fn get_u8_at_pos(v: &[u8], pos: usize) -> u8 {
     v[pos]
 }
 
-fn get_u16_at_pos(v: &Vec<u8>, pos: usize) -> u16 {
+fn get_u16_at_pos(v: &[u8], pos: usize) -> u16 {
     let mut z = [0_u8; 2];
-    for i in 0..2 {
-        z[i] = v[pos + i];
-    }
+    z.clone_from_slice(&v[pos..(2 + pos)]);
     u16::from_le_bytes(z)
 }
 
-fn get_u32_at_pos(v: &Vec<u8>, pos: usize) -> u32 {
+fn get_u32_at_pos(v: &[u8], pos: usize) -> u32 {
     let mut z = [0_u8; 4];
-    for i in 0..4 {
-        z[i] = v[pos + i];
-    }
+    z.clone_from_slice(&v[pos..(4 + pos)]);
     u32::from_le_bytes(z)
 }
 
@@ -121,16 +117,12 @@ fn _put_u8_at_pos(v: &mut Vec<u8>, pos: usize, val: u8) {
 
 fn _put_u16_at_pos(v: &mut Vec<u8>, pos: usize, val: u16) {
     let z = val.to_le_bytes();
-    for i in 0..2 {
-        v[pos + i] = z[i];
-    }
+    v[pos..(2 + pos)].clone_from_slice(&z[..2]);
 }
 
 fn put_u32_at_pos(v: &mut Vec<u8>, pos: usize, val: u32) {
     let z = val.to_le_bytes();
-    for i in 0..4 {
-        v[pos + i] = z[i];
-    }
+    v[pos..(4 + pos)].clone_from_slice(&z[..4]);
 }
 
 fn push_u8(v: &mut Vec<u8>, val: u8) {
@@ -178,9 +170,9 @@ impl MirrorSparseMatrix {
     }
 
     pub fn build_from_vec(
-        x: &Vec<Vec<(i32, i32)>>,
-        row_labels: &Vec<String>,
-        col_labels: &Vec<String>,
+        x: &[Vec<(i32, i32)>],
+        row_labels: &[String],
+        col_labels: &[String],
     ) -> MirrorSparseMatrix {
         let mut max_col = 0_i32;
         for i in 0..x.len() {
@@ -569,6 +561,12 @@ impl MirrorSparseMatrix {
             }
             0
         }
+    }
+}
+
+impl Default for MirrorSparseMatrix {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/perf_stats/Cargo.toml
+++ b/perf_stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "perf_stats"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/pretty_trace/Cargo.toml
+++ b/pretty_trace/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pretty_trace"
 # When version is bumped, version in README.md also needs to be bumped.
-version = "0.5.21"
+version = "0.5.22"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Tools for generating pretty tracebacks and for profiling."

--- a/stirling_numbers/Cargo.toml
+++ b/stirling_numbers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stirling_numbers"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "A few functions relating to Stirling numbers of the second kind."

--- a/stirling_numbers/src/lib.rs
+++ b/stirling_numbers/src/lib.rs
@@ -202,7 +202,7 @@ mod tests {
             "\n\"cargo test\" deliberately fails here because without running in release mode,"
         );
         println!("the test would be too slow.\n");
-        assert!(0 == 1);
+        panic!("aborting");
     }
 
     #[cfg(not(debug_assertions))]

--- a/tables/Cargo.toml
+++ b/tables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tables"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com>"]
 license = "MIT"
 description = "Some tools that are 'internal' for now because they are insufficiently refined and unstable, but which are used by other 'public' crates."

--- a/tables/src/lib.rs
+++ b/tables/src/lib.rs
@@ -11,7 +11,7 @@ use string_utils::strme;
 
 // Package characters with ANSI escape codes that come before them.
 
-pub fn package_characters_with_escapes(c: &Vec<u8>) -> Vec<Vec<u8>> {
+pub fn package_characters_with_escapes(c: &[u8]) -> Vec<Vec<u8>> {
     let mut x = Vec::<Vec<u8>>::new();
     let mut escaped = false;
     let mut package = Vec::<u8>::new();
@@ -33,7 +33,7 @@ pub fn package_characters_with_escapes(c: &Vec<u8>) -> Vec<Vec<u8>> {
     x
 }
 
-pub fn package_characters_with_escapes_char(c: &Vec<char>) -> Vec<Vec<char>> {
+pub fn package_characters_with_escapes_char(c: &[char]) -> Vec<Vec<char>> {
     let mut x = Vec::<Vec<char>>::new();
     let mut escaped = false;
     let mut package = Vec::<char>::new();
@@ -63,7 +63,7 @@ pub fn package_characters_with_escapes_char(c: &Vec<char>) -> Vec<Vec<char>> {
 
 pub fn print_tabular(
     log: &mut Vec<u8>,
-    rows: &Vec<Vec<String>>,
+    rows: &[Vec<String>],
     sep: usize,
     justify: Option<Vec<u8>>,
 ) {
@@ -152,9 +152,9 @@ pub fn visible_width(s: &str) -> usize {
 
 pub fn print_tabular_vbox(
     log: &mut String,
-    rows: &Vec<Vec<String>>,
+    rows: &[Vec<String>],
     sep: usize,
-    justify: &Vec<u8>,
+    justify: &[u8],
     debug_print: bool,
     bold_box: bool,
 ) {
@@ -229,7 +229,7 @@ pub fn print_tabular_vbox(
 
     // Proceed.
 
-    let mut rrr = rows.clone();
+    let mut rrr = rows.to_owned();
     let nrows = rrr.len();
     let mut ncols = 0;
     for i in 0..nrows {
@@ -611,12 +611,8 @@ mod tests {
         ];
         rows.push(row);
         let mut log = String::new();
-        let mut justify = Vec::<u8>::new();
-        justify.push(b'r');
-        justify.push(b'|');
-        justify.push(b'l');
-        justify.push(b'l');
-        print_tabular_vbox(&mut log, &rows, 2, &justify, false, false);
+        let justify = &[b'r', b'|', b'l', b'l'];
+        print_tabular_vbox(&mut log, &rows, 2, justify, false, false);
         let answer = "┌────────┬─────────────────────────┐\n\
                       │ omega  │  superduperfineexcellent│\n\
                       │  woof  │  snarl      octopus     │\n\
@@ -642,11 +638,8 @@ mod tests {
         let row = vec!["fabulous pumpkins".to_string(), "\\ext".to_string()];
         rows.push(row);
         let mut log = String::new();
-        let mut justify = Vec::<u8>::new();
-        justify.push(b'l');
-        justify.push(b'|');
-        justify.push(b'l');
-        print_tabular_vbox(&mut log, &rows, 2, &justify, false, false);
+        let justify = &[b'l', b'|', b'l'];
+        print_tabular_vbox(&mut log, &rows, 2, justify, false, false);
         let answer = "┌────────┬────────┐\n\
                       │pencil  │  pusher│\n\
                       ├────────┴────────┤\n\

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdj_ann"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com"]
 edition = "2018"
 license = "MIT"

--- a/vdj_ann/src/annotate.rs
+++ b/vdj_ann/src/annotate.rs
@@ -66,11 +66,7 @@ pub fn print_start_codon_positions(tig: &DnaString, log: &mut Vec<u8>) {
 //
 // ◼ Ns are incorrectly handled.  See lena 100349 for lots of examples.
 
-pub fn chain_type(
-    b: &DnaString,
-    rkmers_plus_full_20: &Vec<(Kmer20, i32, i32)>,
-    rtype: &Vec<i32>,
-) -> i8 {
+pub fn chain_type(b: &DnaString, rkmers_plus_full_20: &[(Kmer20, i32, i32)], rtype: &[i32]) -> i8 {
     let n = 7;
     let k = 20;
     if b.len() < k {
@@ -1391,11 +1387,11 @@ pub fn annotate_seq_core(
         }
         let rt = refdata.rtype[t];
         if (0..3).contains(&rt) {
-            if refdata.segtype[t] == *"V" {
+            if refdata.segtype[t] == "V" {
                 igv = true;
-            } else if refdata.segtype[t] == *"J" {
+            } else if refdata.segtype[t] == "J" {
                 igj = true;
-            } else if refdata.segtype[t] == *"C"
+            } else if refdata.segtype[t] == "C"
                 && annx[i].3 == 0
                 && annx[i].0 >= J_TOT
                 && refs[t].len() >= J_TOT as usize
@@ -1454,12 +1450,12 @@ pub fn annotate_seq_core(
     let mut to_delete: Vec<bool> = vec![false; annx.len()];
     for i1 in 0..annx.len() {
         let t1 = annx[i1].2 as usize;
-        if !rheaders[t1].contains("segment") && refdata.segtype[t1] == *"D" {
+        if !rheaders[t1].contains("segment") && refdata.segtype[t1] == "D" {
             let mut have_v = false;
             for i2 in 0..annx.len() {
                 let t2 = annx[i2].2 as usize;
                 if !rheaders[t2].contains("segment")
-                    && refdata.segtype[t2] == *"V"
+                    && refdata.segtype[t2] == "V"
                     && refdata.rtype[t1] == refdata.rtype[t2]
                 {
                     have_v = true;
@@ -1484,20 +1480,20 @@ pub fn annotate_seq_core(
     let (mut vstop, mut jstart) = (0, 0);
     const VJTRIM: i32 = 10;
     let mut v_rtype = -2_i32;
-    for i in 0..annx.len() {
-        let t = annx[i].2 as usize;
+    for ann in &annx {
+        let t = ann.2 as usize;
         if !rheaders[t].contains("segment") {
             let rt = refdata.rtype[t];
             if rt == 0 || rt == 4 {
-                if refdata.segtype[t] == *"V" {
+                if refdata.segtype[t] == "V" {
                     v = true;
-                    vstop = annx[i].0 + annx[i].1;
+                    vstop = ann.0 + ann.1;
                     v_rtype = rt;
-                } else if refdata.segtype[t] == *"D" {
+                } else if refdata.segtype[t] == "D" {
                     d = true;
-                } else if refdata.segtype[t] == *"J" {
+                } else if refdata.segtype[t] == "J" {
                     j = true;
-                    jstart = annx[i].0;
+                    jstart = ann.0;
                 }
             }
         }
@@ -1793,7 +1789,7 @@ pub fn annotate_seq_core(
     let max_indel = 27;
     let min_len_gain = 100;
     while j < vs.len() {
-        let k = next_diff1_2(&mut vs, j as i32) as usize;
+        let k = next_diff1_2(&vs, j as i32) as usize;
         if k - j == 1 {
             score.push((annx[j].1, k - j, annx[j].4.len(), vs[j].1));
         } else if k - j == 2 {
@@ -2029,7 +2025,7 @@ pub fn annotate_seq_core(
 
 pub fn print_some_annotations(
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     log: &mut Vec<u8>,
     verbose: bool,
 ) {
@@ -2254,7 +2250,7 @@ pub fn print_cdr3(tig: &DnaStringSlice, log: &mut Vec<u8>) {
 pub fn cdr3_loc<'a>(
     tig: &'a DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
 ) -> DnaStringSlice<'a> {
     // Given the design of this function, the following bound appears to be optimal
     // except possibly for changes less than ten.
@@ -2291,7 +2287,7 @@ pub fn cdr3_loc<'a>(
 pub fn get_cdr3_using_ann(
     tig: &DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     cdr3: &mut Vec<(usize, Vec<u8>, usize, usize)>,
 ) {
     let window = cdr3_loc(tig, refdata, ann);
@@ -2318,7 +2314,7 @@ pub fn get_cdr3_using_ann(
 pub fn print_cdr3_using_ann(
     tig: &DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     log: &mut Vec<u8>,
 ) {
     let mut cdr3 = Vec::<(usize, Vec<u8>, usize, usize)>::new();
@@ -2377,7 +2373,7 @@ impl AnnotationUnit {
     pub fn from_annotate_seq(
         b: &DnaString,
         refdata: &RefData,
-        ann: &Vec<(i32, i32, i32, i32, i32)>,
+        ann: &[(i32, i32, i32, i32, i32)],
     ) -> AnnotationUnit {
         // Sanity check the inputs.  Obviously these conditions should be checked
         // before calling, so that they can never fail.
@@ -2586,9 +2582,9 @@ impl ContigAnnotation {
     pub fn from_annotate_seq(
         b: &DnaString,                           // the contig
         q: &[u8],                                // qual scores for the contig
-        tigname: &String,                        // name of the contig
+        tigname: &str,                           // name of the contig
         refdata: &RefData,                       // reference data
-        ann: &Vec<(i32, i32, i32, i32, i32)>,    // output of annotate_seq
+        ann: &[(i32, i32, i32, i32, i32)],       // output of annotate_seq
         nreads: usize,                           // number of reads assigned to contig
         numis: usize,                            // number of umis assigned to contig
         high_confidencex: bool,                  // declared high confidence?
@@ -2641,7 +2637,7 @@ impl ContigAnnotation {
         }
         let mut ann = ContigAnnotation {
             barcode: tigname.before("_").to_string(),
-            contig_name: tigname.clone(),
+            contig_name: tigname.to_string(),
             sequence: b.to_string(),
             quals: stringme(&qp),
             fraction_of_reads_for_this_barcode_provided_as_input_to_assembly: None,
@@ -2707,7 +2703,7 @@ impl ContigAnnotation {
     pub fn from_seq(
         b: &DnaString,                           // the contig
         q: &[u8],                                // qual scores for the contig
-        tigname: &String,                        // name of the contig
+        tigname: &str,                           // name of the contig
         refdata: &RefData,                       // reference data
         nreads: usize,                           // number of reads assigned to contig
         numis: usize,                            // number of umis assigned to contig
@@ -2771,10 +2767,9 @@ impl ContigAnnotation {
     }
 
     pub fn is_full_length(&self) -> bool {
-        self.full_length.unwrap_or(check_full_length(
-            self.get_region(VdjRegion::V),
-            self.get_region(VdjRegion::J),
-        ))
+        self.full_length.unwrap_or_else(|| {
+            check_full_length(self.get_region(VdjRegion::V), self.get_region(VdjRegion::J))
+        })
     }
 
     /// The chain corresponding to this contig is defined as the chain type of the V-region
@@ -2801,16 +2796,16 @@ fn check_full_length(v_ann: Option<&AnnotationUnit>, j_ann: Option<&AnnotationUn
 pub fn make_annotation_units(
     b: &DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
 ) -> Vec<AnnotationUnit> {
     let mut x = Vec::<AnnotationUnit>::new();
-    let rtype = vec!["U", "V", "D", "J", "C"];
-    for i in 0..rtype.len() {
+    let rtype = &["U", "V", "D", "J", "C"];
+    for &rt in rtype {
         let mut locs = Vec::<(usize, usize, usize)>::new();
         let mut j = 0;
         while j < ann.len() {
             let t = ann[j].2 as usize;
-            if refdata.segtype[t] != *rtype[i] {
+            if refdata.segtype[t] != rt {
                 j += 1;
                 continue;
             }
@@ -2825,10 +2820,10 @@ pub fn make_annotation_units(
                 len += ann[j + 1].1;
             }
             let mut score = len as usize;
-            if refdata.segtype[t] == *"V" && ann[j].3 == 0 {
+            if refdata.segtype[t] == "V" && ann[j].3 == 0 {
                 score += 1_000_000;
             }
-            if refdata.segtype[t] == *"J" && (ann[j].3 + ann[j].1) as usize == refdata.refs[t].len()
+            if refdata.segtype[t] == "J" && (ann[j].3 + ann[j].1) as usize == refdata.refs[t].len()
             {
                 score += 1_000_000;
             }

--- a/vdj_ann/src/transcript.rs
+++ b/vdj_ann/src/transcript.rs
@@ -19,7 +19,7 @@ use vector_utils::{lower_bound1_3, unique_sort};
 pub fn is_valid(
     b: &DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     logme: bool,
     log: &mut Vec<u8>,
 ) -> bool {
@@ -197,7 +197,7 @@ pub fn is_valid(
 pub fn junction_seq(
     tig: &DnaString,
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     jseq: &mut DnaString,
 ) {
     let refs = &refdata.refs;
@@ -243,11 +243,11 @@ pub fn junction_seq(
 
 pub fn junction_supp(
     tig: &DnaString,
-    reads: &Vec<DnaString>,
+    reads: &[DnaString],
     x: &Hyper,
-    umi_id: &Vec<i32>,
+    umi_id: &[i32],
     refdata: &RefData,
-    ann: &Vec<(i32, i32, i32, i32, i32)>,
+    ann: &[(i32, i32, i32, i32, i32)],
     jsupp: &mut (i32, i32),
 ) {
     let mut jseq = DnaString::new();
@@ -256,9 +256,9 @@ pub fn junction_supp(
 }
 
 pub fn junction_supp_core(
-    reads: &Vec<DnaString>,
+    reads: &[DnaString],
     x: &Hyper,
-    umi_id: &Vec<i32>,
+    umi_id: &[i32],
     jseq: &DnaString,
     jsupp: &mut (i32, i32),
 ) {
@@ -271,8 +271,7 @@ pub fn junction_supp_core(
         }
     }
     unique_sort(&mut ids);
-    let mut tigs = Vec::<DnaString>::new();
-    tigs.push(jseq.clone());
+    let tigs = vec![jseq.clone()];
     let mut kmers_plus = Vec::<(Kmer20, i32, i32)>::new();
     make_kmer_lookup_20_single(&tigs, &mut kmers_plus);
     let mut idi = 0;

--- a/vdj_ann_ref/Cargo.toml
+++ b/vdj_ann_ref/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdj_ann_ref"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["David Jaffe <david.jaffe@10xgenomics.com"]
 edition = "2018"
 license = "MIT"
@@ -21,4 +21,4 @@ pretty_trace = "0.5"
 sha2 = "0.9.3"
 string_utils = "0.1"
 vector_utils = "0.1"
-vdj_ann = { version = "0.1", path = "../vdj_ann" }
+vdj_ann = { version = "0.2", path = "../vdj_ann" }


### PR DESCRIPTION
Fix a future-incompatible warning in some `io_util` macros due to trailing
semicolons.

Also fix those macros to work properly when expanded in contexts where
the types they're accessing aren't in scope.  They now expect something
that implements `AsRef<Path>`, which is a breaking API change for
anything passing a `String` rather than `&String` or `&str`.

Add trait implementations where appropriate, mostly `Default` but also a
few for `From` where it looked like it made sense given existing
conversion functions, in order to bring the APIs into conformance with
common naming conventions.

Fix a bunch of clippy lints around stuff that looks like
```rust
if f.is_err() {
    // thing
} else {
    let f = f.unwrap();
    // other thing
}
```
using `match` instead to avoid checking more than once whether the type
was an error.

Replace uses of `&Vec<T>` with `&[T]` where possible.  In some cases,
the extent to which this was possible is limited until some of the
upstream crates (from this repository) push a new version with their
APIs updated.

Replace uses of `&String` with either `&str` or `impl AsRef<Path>`
as appropriate for the use case.  Again, as with the `&Vec<T>` changes,
in some cases this means temporarily going through fallible steps
allocating String objects until the upstream crates publish versions
with updated APIs.

I could be wrong but I believe that `cargo clippy --fix` will be able
to fix the TODOs from the above two items automatically when the time
comes.

The above two changes _shouldn't_ affect existing users, at least in
most cases (`&Vec<T>` casts implicitly to `&[T]`, `&String` casts
implicitly to `&str`, and both `&String` and `&str` implement
`AsRef<Path>`).  At least, in theory.

Change the `segtype` field of `vdj_ann::refx::RefData` from a vector of
owned `String` to a `&'static str`, since everything added to that
vector is a constant value.  This should significantly reduce memory
consumption, as the vector is now a vector of pointers into constant
memory rather than a vector of pointers each into their own heap-
allocated copy of the source strings.  Because that field is public,
this is a breaking API change (though I don't know how many downstream
users actually access the field directly), so I'm bumping the version
of that crate.

In vdj_ann_ref, don't convert `&'static str` to `String` except in
cases where (similarly to above) we have to in order to satisfy the old
APIs.  Also, change the if-chaining logic to `match` statements to make
the different cases more clear.