### PR TITLE
Better error messages when parsing VdjRegion and VdjChain

### DIFF
--- a/vdj_types/Cargo.toml
+++ b/vdj_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdj_types"
-version = "0.1.7"
+version = "0.2.0"
 authors = ["Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"

--- a/vdj_types/Cargo.toml
+++ b/vdj_types/Cargo.toml
@@ -8,10 +8,7 @@ description = "Some tools that are 'internal' for now because they are insuffici
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-enum-iterator = ">=0.6, <0.8"
 serde = { version = "1", features = ["derive"] }
-strum = ">=0.18.0, <0.22"
-strum_macros = ">=0.18.0, <0.22"
 
 [dev-dependencies]
 serde_json = "1"

--- a/vdj_types/src/lib.rs
+++ b/vdj_types/src/lib.rs
@@ -7,6 +7,38 @@ use std::fmt;
 use std::str::FromStr;
 use strum_macros::{Display, EnumIter, EnumString};
 
+macro_rules! make_enum {
+    (
+        name: $name:ident,
+        variants:[$( ($field:ident, $lit: literal) ,)*],
+        const_var_name: $const_var_name:ident,
+    ) => {
+        #[derive(
+            Debug,
+            Copy,
+            Clone,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Serialize,
+            Deserialize,
+            EnumString,
+            Display,
+            EnumIter,
+            IntoEnumIterator,
+            Hash,
+        )]
+        pub enum $name {
+            $(
+                #[strum(to_string = $lit)]
+                #[serde(rename = $lit)]
+                $field,
+            )*
+        }
+    };
+}
+
 /// All the possible heavy and light chains
 #[derive(
     Debug,
@@ -78,39 +110,16 @@ impl TryFrom<&str> for VdjContigChain {
     }
 }
 
-/// Different segments or regions in a full-length receptor transcript
-#[derive(
-    Debug,
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Serialize,
-    Deserialize,
-    EnumString,
-    Display,
-    EnumIter,
-    IntoEnumIterator,
-    Hash,
-)]
-pub enum VdjRegion {
-    #[strum(to_string = "5'UTR")]
-    #[serde(rename = "5'UTR")]
-    UTR, // 5′ untranslated region (5′ UTR)
-    #[strum(to_string = "L-REGION+V-REGION")]
-    #[serde(rename = "L-REGION+V-REGION")]
-    V, // Variable region
-    #[strum(to_string = "D-REGION")]
-    #[serde(rename = "D-REGION")]
-    D, // Diversity region
-    #[strum(to_string = "J-REGION")]
-    #[serde(rename = "J-REGION")]
-    J, // Joining region
-    #[strum(to_string = "C-REGION")]
-    #[serde(rename = "C-REGION")]
-    C, // Constant region
+make_enum! {
+    name: VdjRegion,
+    variants: [
+        (UTR, "5'UTR"), // 5′ untranslated region (5′ UTR)
+        (V, "L-REGION+V-REGION"), // Variable region
+        (D, "D-REGION"), // Diversity region
+        (J, "J-REGION"), // Joining region
+        (C, "C-REGION"), // Constant region
+    ],
+    const_var_name: VDJ_REGIONS,
 }
 
 #[cfg(test)]

--- a/vdj_types/src/lib.rs
+++ b/vdj_types/src/lib.rs
@@ -168,7 +168,7 @@ mod tests {
     #[test]
     fn test_vdj_region_invalid_from_str() {
         assert_eq!(
-            format!("{}", VdjRegion::from_str("V-REGION").unwrap_err()),
+            VdjRegion::from_str("V-REGION").unwrap_err().to_string(),
             "Unknown variant 'V-REGION' for VdjRegion. Supported variants are: [5'UTR, L-REGION+V-REGION, D-REGION, J-REGION, C-REGION]"
         );
     }

--- a/vdj_types/src/lib.rs
+++ b/vdj_types/src/lib.rs
@@ -168,8 +168,16 @@ mod tests {
     #[test]
     fn test_vdj_region_invalid_from_str() {
         assert_eq!(
-            VdjRegion::from_str("V-REGION").unwrap_err().to_string(),
+            VdjRegion::from_str("V-REGION").unwrap_err(),
             "Unknown variant 'V-REGION' for VdjRegion. Supported variants are: [5'UTR, L-REGION+V-REGION, D-REGION, J-REGION, C-REGION]"
+        );
+    }
+
+    #[test]
+    fn test_vdj_chain_invalid_from_str() {
+        assert_eq!(
+            VdjChain::from_str("").unwrap_err(),
+            "Unknown variant '' for VdjChain. Supported variants are: [IGH, IGK, IGL, TRA, TRB, TRD, TRG]"
         );
     }
 


### PR DESCRIPTION
- The `strum` derives fail with an opaque error saying `VariantNotFound`. Replace that with a macro which provides a more detailed error when encountering unknown chains or regions. 