### PR TITLE
Disable clippy::needless_range_loop check.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.57.0
+          toolchain: 1.58.1
           components: rustfmt, clippy
           default: true
       - name: Checkout git repository
@@ -62,8 +62,10 @@ jobs:
            -F clippy::unused_io_amount
            -D clippy::perf
            -D unused
+           -W clippy::redundant_closure_for_method_calls
            -A clippy::many_single_char_names
            -A clippy::comparison_chain
+           -A clippy::needless_range_loop
       - name: Cargo check
         run: RUSTFLAGS="-D unused -D warnings" cargo check --all-targets
       - name: Run Rust tests

--- a/kmer_lookup/src/lib.rs
+++ b/kmer_lookup/src/lib.rs
@@ -53,7 +53,7 @@ pub fn make_kmer_lookup_single_simple<K: Kmer>(dv: &[DnaString], x: &mut Vec<K>)
     x.clear();
     x.reserve(sz);
 
-    x.extend(dv.iter().flat_map(|b| b.iter_kmers::<K>()));
+    x.extend(dv.iter().flat_map(<DnaString as Vmer>::iter_kmers::<K>));
     unique_sort(x);
 }
 

--- a/perf_stats/src/lib.rs
+++ b/perf_stats/src/lib.rs
@@ -137,14 +137,11 @@ pub fn available_mem_gb() -> Option<f64> {
             for line in f.lines() {
                 let s = line.unwrap();
                 if s.starts_with("MemAvailable") {
-                    let split: Vec<&str> = s.split_whitespace().collect();
+                    let split: Vec<&str> = s.split_ascii_whitespace().collect();
                     if split.len() != 3 || split[2] != "kB" {
                         return None;
                     }
-                    if split[1].parse::<i64>().is_err() {
-                        return None;
-                    }
-                    return Some(split[1].force_f64() / (1024 * 1024) as f64);
+                    return Some(split[1].parse::<i64>().ok()? as f64 / (1024_f64 * 1024_f64));
                 }
             }
             None

--- a/stirling_numbers/src/lib.rs
+++ b/stirling_numbers/src/lib.rs
@@ -260,13 +260,14 @@ mod tests {
             let y1 = x1.clone() * n.to_biguint().unwrap();
             let y1x2 = y1 / x2.clone();
 
-            if y1x2 != n.to_biguint().unwrap()
-                && y1x2 != (n - 1).to_biguint().unwrap()
-                && y1x2 != (n + 1).to_biguint().unwrap()
-            {
-                eprintln!("x1 != x2 to {} digits, y1x2 = {}", y1x2, d);
-                assert!(0 == 1);
-            }
+            assert!(
+                y1x2 == n.to_biguint().unwrap()
+                    || y1x2 == (n - 1).to_biguint().unwrap()
+                    || y1x2 == (n + 1).to_biguint().unwrap(),
+                "x1 != x2 to {} digits, y1x2 = {}",
+                y1x2,
+                d
+            );
         }
 
         // Test one value in stirling2_table<f64> versus value in wikipedia.

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -946,7 +946,7 @@ fn main() {
                 "{}/{}/{}/dna/{}.GRCh38.dna.toplevel.fa",
                 releasep, ftype, species_name, csn
             ),
-            _ => format!(""),
+            _ => String::default(),
         }
     }
 

--- a/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
@@ -611,7 +611,7 @@ fn main() {
                 "{}/{}/{}/dna/{}.GRCh38.dna.toplevel.fa",
                 releasep, ftype, species_name, csn
             ),
-            _ => format!(""),
+            _ => String::new(),
         }
     }
 

--- a/vector_utils/src/lib.rs
+++ b/vector_utils/src/lib.rs
@@ -451,14 +451,18 @@ pub fn next_diff1_8<S: Eq, T: Eq, U: Eq, V: Eq, W: Eq, X: Eq, Y: Eq, Z: Eq>(
 // RESIZE WITHOUT SETTING
 // ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
 
-// resize_without_setting: Resize a vector to the given size without initializing
-// the entries.  Capacity is not reduced if it exceeds the given size.  This
-// function is only 'safe' (meaning actually safe) if followed by code that sets all
-// all the entries.  And this should only be used when the type is 'fixed width',
-// e.g. not on Strings or Vecs.
-//
-// Panics if allocation fails.
-
+/// resize_without_setting: Resize a vector to the given size without initializing
+/// the entries.  Capacity is not reduced if it exceeds the given size.
+///
+/// # Safety
+///
+/// After a call to this function, all entries in the vector must be set before
+/// being read.  Only be used when the type is 'fixed width', e.g. not on
+/// Strings or Vecs, cannot own any allocated objects, or implement the Drop
+/// trait.
+///
+/// Panics if allocation fails.
+#[warn(clippy::uninit_vec)]
 pub unsafe fn resize_without_setting<T>(x: &mut Vec<T>, n: usize) {
     x.clear();
     x.reserve(n);


### PR DESCRIPTION
It's much too noisy.

Fix a missing documentation lint by expanding on the ways in which
resize_without_setting is unsafe, and also demote a clippy warning from
inside it.

Fix a bunch of clippy warnings (some automatic fixes, some manual).