### PR TITLE
Add path = ../... for interdependencies.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           path: ~/.cargo/git
           key: ${{runner.os}}-cargo-git-${{hashFiles('**/*.rs')}}
           restore-keys: ${{runner.os}}-cargo-git-
-      - name: Cache cargo build --release
+      - name: Cache cargo build --release --all-targets
         uses: actions/cache@v1
         with:
           path: target
@@ -62,7 +62,7 @@ jobs:
           # TODO: re-enable some the -A lints below once we're clean on other
           # more important ones.
           args: |
-           --all-features --all-targets --
+           --all-features --all-targets --locked --release --
            -W clippy::wildcard_imports
            -W clippy::float_cmp
            -W future_incompatible
@@ -77,6 +77,8 @@ jobs:
            -A clippy::comparison_chain
            -A clippy::needless_range_loop
       - name: Cargo check
-        run: RUSTFLAGS="-D unused -D warnings" cargo check --all-targets
+        run: RUSTFLAGS="-D unused -D warnings" cargo check --frozen --all-targets --release
+      - name: Build tests
+        run: cargo test --no-run --frozen --release
       - name: Run Rust tests
-        run: cargo test --release -- --nocapture
+        run: cargo test --frozen --release -- --nocapture

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,14 @@ jobs:
         uses: actions/checkout@master
       - name: Check Rust formatting
         run: cargo fmt -- --check
+      - name: Install cargo-deny
+        run: |
+          wget https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz
+          tar -xvf cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz
+          mkdir -p ~/bin/
+          cp cargo-deny-0.11.3-x86_64-unknown-linux-musl/cargo-deny ~/bin/
+          rm -r cargo-deny-*
+          echo "$HOME/bin" >> $GITHUB_PATH
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:
@@ -46,6 +54,8 @@ jobs:
       - name: Remove the Cargo target directory
         if: github.ref == 'refs/heads/master'
         run: cargo clean
+      - name: Deny duplicate dependencies
+        run: cargo deny --locked check
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,21 +33,8 @@ dependencies = [
  "bio_edit",
  "debruijn",
  "itertools",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "align_tools"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff21503efd43332c9ef1a6d04ac55b7f8c8878655d6c28c7f749823ac0186406"
-dependencies = [
- "bio_edit",
- "debruijn",
- "itertools",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
+ "vector_utils",
 ]
 
 [[package]]
@@ -55,25 +42,15 @@ name = "amino"
 version = "0.1.7"
 dependencies = [
  "debruijn",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "amino"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd6d116795099c91389d0d065b0a8ca053f15b38df74f31f6c935cbc4629e6c"
-dependencies = [
- "debruijn",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
 ]
 
 [[package]]
 name = "ansi_escape"
 version = "0.1.3"
 dependencies = [
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
+ "vector_utils",
 ]
 
 [[package]]
@@ -120,15 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "binary_vec_io"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b26a64da90d37568da288a76425c5efd45278a92e71ca544f6d366048bd03a"
-dependencies = [
- "itertools",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,8 +121,6 @@ dependencies = [
 [[package]]
 name = "bio_edit"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b4b0768c61eb19dad63fbb3cd4f56db42dc0b80ee66d371784c799c196c0ba"
 dependencies = [
  "bio-types",
  "bit-set",
@@ -364,12 +330,6 @@ name = "equiv"
 version = "0.1.3"
 
 [[package]]
-name = "equiv"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad251ad0f0bd07cfe4ff98ed118a6fa615fe89be43236e123228dc55f4b15f0c"
-
-[[package]]
 name = "evalexpr"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,20 +339,9 @@ checksum = "0eb8c3fede1e2612da9d84fc2a20769b269c8a3d6d29e0854c22f336db343701"
 name = "exons"
 version = "0.1.5"
 dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "exons"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ade6e4dae7e83c43060ed785ae734608cda540c055acc59f80efa582e30068"
-dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
+ "string_utils",
+ "vector_utils",
 ]
 
 [[package]]
@@ -401,20 +350,8 @@ version = "0.1.3"
 dependencies = [
  "evalexpr",
  "statrs",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fasta_tools"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47968b60700da803afa3a0f7000e947ca56ccb6b2b0f8768a77ebccb8fe39680"
-dependencies = [
- "debruijn",
- "flate2",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
+ "vector_utils",
 ]
 
 [[package]]
@@ -423,8 +360,8 @@ version = "0.1.8"
 dependencies = [
  "debruijn",
  "flate2",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
+ "string_utils",
 ]
 
 [[package]]
@@ -498,17 +435,7 @@ name = "graph_simple"
 version = "0.1.5"
 dependencies = [
  "petgraph",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "graph_simple"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41db170d943bdc507695fc6c5ba41e12ce2c074e0310aad5bb64edb2c70308e6"
-dependencies = [
- "petgraph",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vector_utils",
 ]
 
 [[package]]
@@ -540,25 +467,11 @@ name = "hyperbase"
 version = "0.1.8"
 dependencies = [
  "debruijn",
- "equiv 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph_simple 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kmer_lookup 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "equiv",
+ "graph_simple",
+ "kmer_lookup",
  "petgraph",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hyperbase"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4149ebb430498aa1c8fcc2bfa348df892a34a66218abbe3474fe241f503d3d"
-dependencies = [
- "debruijn",
- "equiv 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "graph_simple 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kmer_lookup 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "petgraph",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vector_utils",
 ]
 
 [[package]]
@@ -588,20 +501,7 @@ dependencies = [
  "flate2",
  "lz4",
  "serde",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "io_utils"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88c239b08f2e90f0f0d71faab2975ee25f70af3869afb442ffd327219eed1ae"
-dependencies = [
- "bincode",
- "flate2",
- "lz4",
- "serde",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
 ]
 
 [[package]]
@@ -625,18 +525,7 @@ version = "0.1.5"
 dependencies = [
  "debruijn",
  "rayon",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "kmer_lookup"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b99223e43a9eb74be262b78b33727e1a70a224f96db44063632de610938dfd"
-dependencies = [
- "debruijn",
- "rayon",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vector_utils",
 ]
 
 [[package]]
@@ -662,8 +551,8 @@ name = "load_feature_bc"
 version = "0.1.7"
 dependencies = [
  "flate2",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
+ "string_utils",
 ]
 
 [[package]]
@@ -752,9 +641,9 @@ dependencies = [
 name = "mirror_sparse_matrix"
 version = "0.1.17"
 dependencies = [
- "binary_vec_io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_trace 0.5.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "binary_vec_io",
+ "io_utils",
+ "pretty_trace",
 ]
 
 [[package]]
@@ -911,20 +800,9 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 name = "perf_stats"
 version = "0.1.8"
 dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
  "libc",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "perf_stats"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0177fac70981a979322d624a0c4820d0c698b975267c92f34a5f15ccf3f9a8d"
-dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
 ]
 
 [[package]]
@@ -977,34 +855,16 @@ name = "pretty_trace"
 version = "0.5.23"
 dependencies = [
  "backtrace",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
  "lazy_static",
  "libc",
  "nix",
  "pprof",
  "rayon",
- "stats_utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tables 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pretty_trace"
-version = "0.5.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb7fee4fba2b897a4dabb1d95c746960aea01dbd2de45080cfb2bb32f4b7d2a"
-dependencies = [
- "backtrace",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static",
- "libc",
- "nix",
- "pprof",
- "stats_utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tables 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stats_utils",
+ "string_utils",
+ "tables",
+ "vector_utils",
 ]
 
 [[package]]
@@ -1292,12 +1152,6 @@ name = "stats_utils"
 version = "0.1.3"
 
 [[package]]
-name = "stats_utils"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d615734a36694d0a5803b1fe69b185611864224f5b2d4425ad0b69e39fb877"
-
-[[package]]
 name = "stirling_numbers"
 version = "0.1.7"
 dependencies = [
@@ -1306,23 +1160,14 @@ dependencies = [
  "num-traits",
  "rand",
  "rayon",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vector_utils",
 ]
 
 [[package]]
 name = "string_utils"
 version = "0.1.4"
 dependencies = [
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "string_utils"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0247f2b34eb8810f2bab2b5d2fb1abc5f7d446ce23712efc463aa1c51e5021d0"
-dependencies = [
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vector_utils",
 ]
 
 [[package]]
@@ -1382,20 +1227,9 @@ dependencies = [
 name = "tables"
 version = "0.1.5"
 dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
  "itertools",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tables"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ee0c732e620e592ba3ad7cafceef32028e185c7bf6c8e34b367565bf3b43ece"
-dependencies = [
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
 ]
 
 [[package]]
@@ -1458,46 +1292,23 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "vdj_ann"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9d0a7fad1e932f77983ffd9be8b84a185a93696a4ad2ae817b832c96b0a3f6"
-dependencies = [
- "align_tools 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "amino 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "bio_edit",
- "debruijn",
- "fasta_tools 0.1.7",
- "hyperbase 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools",
- "kmer_lookup 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_json",
- "stats_utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vdj_types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "vdj_ann"
 version = "0.4.3"
 dependencies = [
- "align_tools 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "amino 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "align_tools",
+ "amino",
  "bio_edit",
  "debruijn",
- "fasta_tools 0.1.7",
- "hyperbase 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fasta_tools",
+ "hyperbase",
+ "io_utils",
  "itertools",
- "kmer_lookup 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kmer_lookup",
  "serde",
  "serde_json",
- "stats_utils 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vdj_types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stats_utils",
+ "string_utils",
+ "vdj_types",
+ "vector_utils",
 ]
 
 [[package]]
@@ -1505,17 +1316,17 @@ name = "vdj_ann_ref"
 version = "0.2.1"
 dependencies = [
  "debruijn",
- "exons 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "fasta_tools 0.1.7",
+ "exons",
+ "fasta_tools",
  "flate2",
- "io_utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "kmer_lookup 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "perf_stats 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pretty_trace 0.5.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "io_utils",
+ "kmer_lookup",
+ "perf_stats",
+ "pretty_trace",
  "sha2",
- "string_utils 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vdj_ann 0.4.2",
- "vector_utils 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string_utils",
+ "vdj_ann",
+ "vector_utils",
 ]
 
 [[package]]
@@ -1527,27 +1338,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "vdj_types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029dbe2aecc529693aecdf5f8f7cab1a647ed7df5c8e3bf13ab1f2907745be91"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "vector_utils"
 version = "0.1.5"
-dependencies = [
- "permutation",
- "superslice",
-]
-
-[[package]]
-name = "vector_utils"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ecf8ee11bfddd2cb41fe07abbb063610a90d22515b47718d1a7ba200d3059"
 dependencies = [
  "permutation",
  "superslice",

--- a/align_tools/Cargo.toml
+++ b/align_tools/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 edition = "2018"
 
 [dependencies]
-bio_edit = "0.1"
+bio_edit = { version = "0.1", path = "../bio_edit" }
 debruijn = "0.3"
 itertools = ">= 0.8, <= 0.11"
-string_utils = "0.1"
-vector_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/amino/Cargo.toml
+++ b/amino/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 
 [dependencies]
 debruijn = "0.3"
-string_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/ansi_escape/Cargo.toml
+++ b/ansi_escape/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-string_utils = "0.1"
-vector_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/bio_edit/src/alignment/pairwise/mod.rs
+++ b/bio_edit/src/alignment/pairwise/mod.rs
@@ -11,8 +11,8 @@
 //! # Example
 //!
 //! ```
-//! use bio::alignment::pairwise::*;
-//! use bio::alignment::AlignmentOperation::*;
+//! use bio_edit::alignment::pairwise::*;
+//! use bio_edit::alignment::AlignmentOperation::*;
 //!
 //! let x = b"ACCGTGGAT";
 //! let y = b"AAAAACCGTTGAT";
@@ -255,7 +255,7 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `gap_open` - the score for opening a gap (should not be positive)
     /// * `gap_extend` - the score for extending a gap (should not be positive)
     /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    ///    (see also [`bio_edit::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn new(gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         assert!(gap_open <= 0, "gap_open can't be positive");
         assert!(gap_extend <= 0, "gap_extend can't be positive");
@@ -279,7 +279,7 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `penalty` - Clipping penalty for x (both prefix and suffix, should not be positive)
     ///
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).xclip(-5);
     /// assert!(scoring.xclip_prefix == -5);
     /// assert!(scoring.yclip_prefix == MIN_SCORE);
@@ -301,7 +301,7 @@ impl<F: MatchFunc> Scoring<F> {
     ///
     /// # Example
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).xclip_prefix(-5);
     /// assert!(scoring.xclip_prefix == -5);
     /// assert!(scoring.yclip_prefix == MIN_SCORE);
@@ -321,7 +321,7 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `penalty` - Suffix clipping penalty for x (should not be positive)
     ///
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).xclip_suffix(-5);
     /// assert!(scoring.xclip_prefix == MIN_SCORE);
     /// assert!(scoring.yclip_prefix == MIN_SCORE);
@@ -341,7 +341,7 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `penalty` - Clipping penalty for y (both prefix and suffix, should not be positive)
     ///
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).yclip(-5);
     /// assert!(scoring.xclip_prefix == MIN_SCORE);
     /// assert!(scoring.yclip_prefix == -5);
@@ -362,12 +362,12 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `penalty` - Prefix clipping penalty for y (should not be positive)
     ///
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).yclip_prefix(-5);
-    /// assert!(scoring.xclip_prefix == MIN_SCORE);
-    /// assert!(scoring.yclip_prefix == -5);
-    /// assert!(scoring.xclip_suffix == MIN_SCORE);
-    /// assert!(scoring.yclip_suffix == MIN_SCORE);
+    /// assert_eq!(scoring.xclip_prefix, MIN_SCORE);
+    /// assert_eq!(scoring.yclip_prefix, -5);
+    /// assert_eq!(scoring.xclip_suffix, MIN_SCORE);
+    /// assert_eq!(scoring.yclip_suffix, MIN_SCORE);
     /// ```
     pub fn yclip_prefix(mut self, penalty: i32) -> Self {
         assert!(penalty <= 0, "Clipping penalty can't be positive");
@@ -382,7 +382,7 @@ impl<F: MatchFunc> Scoring<F> {
     /// * `penalty` - Suffix clipping penalty for y (should not be positive)
     ///
     /// ```rust
-    /// use bio::alignment::pairwise::{Scoring, MIN_SCORE};
+    /// use bio_edit::alignment::pairwise::{Scoring, MIN_SCORE};
     /// let scoring = Scoring::from_scores(0, -2, 1, -2).yclip_suffix(-5);
     /// assert!(scoring.xclip_prefix == MIN_SCORE);
     /// assert!(scoring.yclip_prefix == MIN_SCORE);
@@ -432,9 +432,9 @@ impl<F: MatchFunc> Scoring<F> {
 /// `Sn` is the last column of the matrix. This is needed to keep track of
 /// suffix clipping scores
 ///
-/// `traceback` - see [`bio::alignment::pairwise::TracebackCell`](struct.TracebackCell.html)
+/// `traceback` - see [`bio_edit::alignment::pairwise::TracebackCell`](struct.TracebackCell.html)
 ///
-/// `scoring` - see [`bio::alignment::pairwise::Scoring`](struct.Scoring.html)
+/// `scoring` - see [`bio_edit::alignment::pairwise::Scoring`](struct.Scoring.html)
 #[allow(non_snake_case)]
 pub struct Aligner<F: MatchFunc> {
     I: [Vec<i32>; 2],
@@ -458,7 +458,7 @@ impl<F: MatchFunc> Aligner<F> {
     /// * `gap_open` - the score for opening a gap (should be negative)
     /// * `gap_extend` - the score for extending a gap (should be negative)
     /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    ///    (see also [`bio_edit::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn new(gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         Aligner::with_capacity(
             DEFAULT_ALIGNER_CAPACITY,
@@ -479,7 +479,7 @@ impl<F: MatchFunc> Aligner<F> {
     /// * `gap_open` - the score for opening a gap (should be negative)
     /// * `gap_extend` - the score for extending a gap (should be negative)
     /// * `match_fn` - function that returns the score for substitutions
-    ///    (see also [`bio::alignment::pairwise::Scoring`](struct.Scoring.html))
+    ///    (see also [`bio_edit::alignment::pairwise::Scoring`](struct.Scoring.html))
     pub fn with_capacity(m: usize, n: usize, gap_open: i32, gap_extend: i32, match_fn: F) -> Self {
         assert!(gap_open <= 0, "gap_open can't be positive");
         assert!(gap_extend <= 0, "gap_extend can't be positive");
@@ -500,7 +500,7 @@ impl<F: MatchFunc> Aligner<F> {
     ///
     /// # Arguments
     ///
-    /// * `scoring` - the scoring struct (see bio::alignment::pairwise::Scoring)
+    /// * `scoring` - the scoring struct (see bio_edit::alignment::pairwise::Scoring)
     pub fn with_scoring(scoring: Scoring<F>) -> Self {
         Aligner::with_capacity_and_scoring(
             DEFAULT_ALIGNER_CAPACITY,

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,94 @@
+# Only the specified targets will be checked when running `cargo deny check`.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    { triple = "x86_64-unknown-linux-gnu" },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+# db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+]
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+unlicensed = "deny"
+# Allow us to keep a consistent list across projects without needing
+# to customize deny.toml based on what's actually present.
+unused-allowed-license = "allow"
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "OpenSSL",
+    "WTFPL",
+]
+copyleft = "deny"
+allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.6
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+highlight = "all"
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate 
+# detection. Unlike skip, it also includes the entire tree of transitive 
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []
+
+[sources.allow-org]
+github = ["10XGenomics"]

--- a/exons/Cargo.toml
+++ b/exons/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 edition = "2018"
 
 [dependencies]
-io_utils = "0.3"
-string_utils = "0.1"
-vector_utils = "0.1"
+io_utils = { version = "0.3", path = "../io_utils" }
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/expr_tools/Cargo.toml
+++ b/expr_tools/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 
 evalexpr = "7"
 statrs = "0.15"
-string_utils = "0.1"
-vector_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/fasta_tools/Cargo.toml
+++ b/fasta_tools/Cargo.toml
@@ -10,5 +10,5 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 [dependencies]
 debruijn = "0.3"
 flate2 = "1"
-io_utils = "0.3"
-string_utils = "0.1"
+io_utils = { version = "0.3", path = "../io_utils" }
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/graph_simple/Cargo.toml
+++ b/graph_simple/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 
 [dependencies]
 petgraph = ">=0.5,<0.7"
-vector_utils = "0.1"
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/hyperbase/Cargo.toml
+++ b/hyperbase/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 
 [dependencies]
 debruijn = "0.3"
-equiv = "0.1"
-graph_simple = "0.1"
-kmer_lookup = "0.1"
+equiv = { version = "0.1", path = "../equiv" }
+graph_simple = { version = "0.1", path = "../graph_simple" }
+kmer_lookup = { version = "0.1", path = "../kmer_lookup" }
 petgraph = ">=0.5,<0.7"
-vector_utils = "0.1"
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/io_utils/Cargo.toml
+++ b/io_utils/Cargo.toml
@@ -13,4 +13,4 @@ bincode = "1.1.3"
 flate2 = "1"
 lz4 = "1"
 serde = { version = "1", features = ["derive"] }
-string_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/kmer_lookup/Cargo.toml
+++ b/kmer_lookup/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 [dependencies]
 debruijn = "0.3"
 rayon = "1"
-vector_utils = "0.1"
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/load_feature_bc/Cargo.toml
+++ b/load_feature_bc/Cargo.toml
@@ -9,5 +9,5 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 flate2 = "1"
-io_utils = "0.3"
-string_utils = "0.1"
+io_utils = { version = "0.3", path = "../io_utils" }
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/master.toml
+++ b/master.toml
@@ -1,50 +1,50 @@
-align_tools = "0.1"
-amino = "0.1"
-ansi_escape = "0.1"
-binary_vec_io = "0.1"
-bio_edit = "0.1"
+align_tools = { version = "0.1", path = "../align_tools" }
+amino = { version = "0.1", path = "../amino" }
+ansi_escape = { version = "0.1", path = "../ansi_escape" }
+binary_vec_io = { version = "0.1", path = "../binary_vec_io" }
+bio_edit = { version = "0.1", path = "../bio_edit" }
 bio-types = "0.12"
 bit-set = "0.5"
 debruijn = "0.3"
-dna = "0.1"
+dna = { version = "0.1", path = "../dna" }
 enum-iterator = ">=0.6, <0.8"
-equiv = "0.1"
+equiv = { version = "0.1", path = "../equiv" }
 evalexpr = "7"
-exons = "0.1"
-fasta_tools = "0.1"
+exons = { version = "0.1", path = "../exons" }
+fasta_tools =  { version = "0.1", path = "../fasta_tools" }
 flate2 = "1"
-graph_simple = "0.1"
-hyperbase = "0.1"
-io_utils = "0.3"
+graph_simple = { version = "0.1", path = "../graph_simple" }
+hyperbase = { version = "0.1", path = "../hyperbase" }
+io_utils = { version = "0.3", path = "../io_utils" }
 itertools = ">= 0.8, <= 0.11"
-kmer_lookup = "0.1"
+kmer_lookup = { version = "0.1", path = "../kmer_lookup" }
 lazy_static = "1"
 libc = "0.2"
-load_feature_bc = "0.1"
+load_feature_bc = { version = "0.1", path = "../load_feature_bc" }
 lz4 = "1"
-mirror_sparse_matrix = "0.1"
+mirror_sparse_matrix = { version = "0.1", path = "../mirror_sparse_matrix" }
 nix = ">=0.19.1, <0.24"
 num-bigint = "^0.4"
 num-rational = "^0.4"
 num-traits = "^0.2"
-perf_stats = "0.1"
+perf_stats = { version = "0.1", path = "../perf_stats" }
 permutation = "0.2"
 petgraph = ">=0.5,<0.7"
 pprof = { version = "0.6", features = ["protobuf"] }
-pretty_trace = "0.5"
+pretty_trace = { version = "0.5", path = "../pretty_trace" }
 rand = ">=0.7.3, <0.9"
 rayon = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = ">=0.9.3, <0.11"
 statrs = "0.15"
-stats_utils = "0.1"
-stirling_numbers = "0.1"
-string_utils = "0.1"
+stats_utils = { version = "0.1", path = "../stats_utils" }
+stirling_numbers = { version = "0.1", path = "../stirling_numbers" }
+string_utils = { version = "0.1", path = "../string_utils" }
 strum = ">=0.18.0, <0.22"
 strum_macros = ">=0.18.0, <0.22"
 superslice = "1"
-tables = "0.1"
-vdj_ann = "0.4"
-vdj_types = "0.2"
-vector_utils = "0.1"
+tables = { version = "0.1", path = "../tables" }
+vdj_ann = { version = "0.4", path = "../vdj_ann" }
+vdj_types = { version = "0.2", path = "../vdj_types" }
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/mirror_sparse_matrix/Cargo.toml
+++ b/mirror_sparse_matrix/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-binary_vec_io = "0.1"
+binary_vec_io = { version = "0.1", path = "../binary_vec_io" }
 
 [dev-dependencies]
-io_utils = "0.3"
-pretty_trace = "0.5"
+io_utils = { version = "0.3", path = "../io_utils" }
+pretty_trace = { version = "0.5", path = "../pretty_trace" }

--- a/perf_stats/Cargo.toml
+++ b/perf_stats/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-io_utils = "0.3"
+io_utils = { version = "0.3", path = "../io_utils" }
 libc = "0.2"
-string_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/pretty_trace/Cargo.toml
+++ b/pretty_trace/Cargo.toml
@@ -13,15 +13,15 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
 backtrace = "0.3.40"
-io_utils = "0.3"
+io_utils = { version = "0.3", path = "../io_utils" }
 lazy_static = "1"
 libc = "0.2"
 nix = ">=0.19.1, <0.24"
 pprof = { version = "0.6", features = ["protobuf"] }
-stats_utils = "0.1"
-tables = "0.1"
-string_utils = "0.1"
-vector_utils = "0.1"
+stats_utils = { version = "0.1", path = "../stats_utils" }
+tables = { version = "0.1", path = "../tables" }
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }
 
 [dev-dependencies]
 rayon = "1"

--- a/stirling_numbers/Cargo.toml
+++ b/stirling_numbers/Cargo.toml
@@ -16,4 +16,4 @@ num-bigint = "^0.4"
 num-rational = "^0.4"
 rand = ">=0.7.3, <0.9"
 rayon = "1"
-vector_utils = "0.1"
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/string_utils/Cargo.toml
+++ b/string_utils/Cargo.toml
@@ -9,4 +9,4 @@ include = ["src/lib.rs", "LICENSE", "README.md"]
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-vector_utils = "0.1"
+vector_utils = { version = "0.1", path = "../vector_utils" }

--- a/tables/Cargo.toml
+++ b/tables/Cargo.toml
@@ -8,6 +8,6 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 edition = "2018"
 
 [dependencies]
-io_utils = "0.3"
+io_utils = { version = "0.3", path = "../io_utils" }
 itertools = ">= 0.8, <= 0.11"
-string_utils = "0.1"
+string_utils = { version = "0.1", path = "../string_utils" }

--- a/vdj_ann/Cargo.toml
+++ b/vdj_ann/Cargo.toml
@@ -11,18 +11,18 @@ repository = "https://github.com/10XGenomics/rust-toolbox"
 include = ["src/**/*"]
 
 [dependencies]
-align_tools = "0.1"
-amino = "0.1"
-bio_edit = "0.1"
+align_tools = { version = "0.1", path = "../align_tools" }
+amino = { version = "0.1", path = "../amino" }
+bio_edit = { version = "0.1", path = "../bio_edit" }
 debruijn = "0.3"
-fasta_tools = "0.1"
-hyperbase = "0.1"
-io_utils = "0.3"
+fasta_tools =  { version = "0.1", path = "../fasta_tools" }
+hyperbase = { version = "0.1", path = "../hyperbase" }
+io_utils = { version = "0.3", path = "../io_utils" }
 itertools = ">= 0.8, <= 0.11"
-kmer_lookup = "0.1"
+kmer_lookup = { version = "0.1", path = "../kmer_lookup" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-stats_utils = "0.1"
-string_utils = "0.1"
-vector_utils = "0.1"
-vdj_types = "0.2"
+stats_utils = { version = "0.1", path = "../stats_utils" }
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }
+vdj_types = { version = "0.2", path = "../vdj_types" }

--- a/vdj_ann_ref/Cargo.toml
+++ b/vdj_ann_ref/Cargo.toml
@@ -12,14 +12,14 @@ publish = false
 
 [dependencies]
 debruijn = "0.3"
-exons = "0.1"
-fasta_tools = "0.1"
+exons = { version = "0.1", path = "../exons" }
+fasta_tools =  { version = "0.1", path = "../fasta_tools" }
 flate2 = "1"
-io_utils = "0.3"
-kmer_lookup = "0.1"
-perf_stats = "0.1"
-pretty_trace = "0.5"
+io_utils = { version = "0.3", path = "../io_utils" }
+kmer_lookup = { version = "0.1", path = "../kmer_lookup" }
+perf_stats = { version = "0.1", path = "../perf_stats" }
+pretty_trace = { version = "0.5", path = "../pretty_trace" }
 sha2 = ">=0.9.3, <0.11"
-string_utils = "0.1"
-vector_utils = "0.1"
-vdj_ann = "0.4"
+string_utils = { version = "0.1", path = "../string_utils" }
+vector_utils = { version = "0.1", path = "../vector_utils" }
+vdj_ann = { version = "0.4", path = "../vdj_ann" }


### PR DESCRIPTION
This is in addition to the existing version constraint, which is
required for publishing.  It allows for much easier development when
working on changes which cut across several crates, as well as faster
builds due to not building crates multiple times.

Also add a cargo-deny config to check for accidental introduction of
duplicated dependencies, dependencies with unacceptable licenses, or
dependencies with known security vulnerabilities.