### PR TITLE
Bump bio-types from 0.12.1 to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "bio-types"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bc4296477f37f54e4fd21efaf48a7fa40fbb289bfbf338af5fbbe42797acb6"
+checksum = "dfa990f40a28735fa598dc3dd58d73e62e6b41458959d623903b927ba7b04c80"
 dependencies = [
  "derive-new",
  "lazy_static",

--- a/bio_edit/Cargo.toml
+++ b/bio_edit/Cargo.toml
@@ -21,5 +21,5 @@ description = "Some tools that are 'internal' for now because they are insuffici
 repository = "https://github.com/10XGenomics/rust-toolbox"
 
 [dependencies]
-bio-types = "0.12"
+bio-types = ">= 0.12, < 1"
 bit-set = "0.5"


### PR DESCRIPTION
Relax the dependency on `bio-types` from `0.12` to `>= 0.12, < 1`.
