### PR TITLE
Loosen type constraints on bin_possition etc.

### DIFF
--- a/expr_tools/src/lib.rs
+++ b/expr_tools/src/lib.rs
@@ -39,7 +39,7 @@ pub fn vars_of_node(n: &evalexpr::Node) -> Vec<String> {
 pub fn test_functions_in_node(n: &evalexpr::Node) -> Result<(), String> {
     let x = evalexpr_function_names();
     for i in n.iter_function_identifiers() {
-        if !bin_member(&x, &(*i).to_string()) {
+        if !bin_member(&x, i) {
             return Err(format!("Unknown function name {} in expression.", i));
         }
     }

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -1231,12 +1231,12 @@ fn main() {
             if rheaders.len() == all_chrs.len() {
                 break;
             }
-            let mut h = s.get(1..).unwrap().to_string();
+            let mut h = s.get(1..).unwrap();
             if h.contains(' ') {
-                h = h.before(" ").to_string();
+                h = h.before(" ");
             }
-            if bin_member(&all_chrs, &h) {
-                rheaders.push(h.clone());
+            if bin_member(&all_chrs, h) {
+                rheaders.push(h.to_string());
                 using = true;
             } else {
                 using = false;

--- a/vdj_ann_ref/src/bin/build_vdj_ref.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref.rs
@@ -443,7 +443,7 @@ fn main() {
     // genomics.  If the bool field ("fw") is false, the given coordinates are used
     // to extract a sequence, and then it is reversed.
 
-    let excluded_genes = vec![];
+    let excluded_genes = Vec::<&str>::new();
     let mut allowed_pseudogenes = Vec::<&str>::new();
     let mut deleted_genes = Vec::<&str>::new();
     let mut added_genes = Vec::<(&str, &str, usize, usize, bool)>::new();

--- a/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
+++ b/vdj_ann_ref/src/bin/build_vdj_ref_exons.rs
@@ -867,12 +867,12 @@ fn main() {
             if rheaders.len() == all_chrs.len() {
                 break;
             }
-            let mut h = s.get(1..).unwrap().to_string();
+            let mut h = s.get(1..).unwrap();
             if h.contains(' ') {
-                h = h.before(" ").to_string();
+                h = h.before(" ")
             }
-            if bin_member(&all_chrs, &h) {
-                rheaders.push(h.clone());
+            if bin_member(&all_chrs, h) {
+                rheaders.push(h.to_string());
                 using = true;
             } else {
                 using = false;


### PR DESCRIPTION
They now permit e.g. searching a &[String] for a &str, rather than requiring a &String for the search parameter.  The requirement is that the type in the slice implements Borrow<T> (for which there is a blanket implementation `borrow(&T) -> &T`).  This is a backwards-compatible change except in so far as it may alter the compiler's ability to infer types in some weird cases which are probably bugs anyway.